### PR TITLE
Fix #7 - Small screenshots

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/DrawFragment.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/DrawFragment.java
@@ -83,14 +83,13 @@ public class DrawFragment extends Fragment {
         if (imageUri != null) {
             try {
                 // There seems to be an issue when using setImageUri that causes density to be chosen incorrectly
+                // See: https://code.google.com/p/android/issues/detail?id=201491. This is fixed in API 24
                 InputStream stream = getActivity().getContentResolver().openInputStream(imageUri);
 
-                BitmapFactory.Options opts = new BitmapFactory.Options();
-                opts.inPreferredConfig = Bitmap.Config.RGB_565;
-                Bitmap b = BitmapFactory.decodeStream(stream);
-                paper.setImageBitmap(b);
-            } catch (FileNotFoundException e) {
-                Log.e("Screenshot error", e.getMessage(), e);
+                Bitmap bitmap = BitmapFactory.decodeStream(stream);
+                paper.setImageBitmap(bitmap);
+            } catch (FileNotFoundException exception) {
+                Log.e("Screenshot error", exception.getMessage(), exception);
             }
         }
 

--- a/shaky/src/main/java/com/linkedin/android/shaky/DrawFragment.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/DrawFragment.java
@@ -17,6 +17,7 @@ package com.linkedin.android.shaky;
 
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -32,6 +33,7 @@ import android.widget.Toast;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
@@ -79,7 +81,17 @@ public class DrawFragment extends Fragment {
         paper = (Paper) view.findViewById(R.id.shaky_paper);
         imageUri = getArguments().getParcelable(KEY_IMAGE_URI);
         if (imageUri != null) {
-            paper.setImageURI(imageUri);
+            try {
+                // There seems to be an issue when using setImageUri that causes density to be chosen incorrectly
+                InputStream stream = getActivity().getContentResolver().openInputStream(imageUri);
+
+                BitmapFactory.Options opts = new BitmapFactory.Options();
+                opts.inPreferredConfig = Bitmap.Config.RGB_565;
+                Bitmap b = BitmapFactory.decodeStream(stream);
+                paper.setImageBitmap(b);
+            } catch (FileNotFoundException e) {
+                Log.e("Screenshot error", e.getMessage(), e);
+            }
         }
 
         view.findViewById(R.id.shaky_button_clear).setOnClickListener(createClearClickListener());


### PR DESCRIPTION
This fixes issue #7, where screenshots would be very small when displayed for markup,
and continue shrinking every time you went back to edit the image.

The issue seems to be caused by an incorrect screen density being used when loading
the screenshot image. This causes the image to scale to a smaller image.
![shakyimage](https://cloud.githubusercontent.com/assets/3112115/18210334/e2917a44-70ec-11e6-8e88-908314bb7345.png)
