### PR TITLE
Add API for manually triggering the feedback flow

### DIFF
--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyApplication.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyApplication.java
@@ -16,6 +16,7 @@
 package com.linkedin.android.shaky.app;
 
 import android.app.Application;
+import android.support.annotation.NonNull;
 import com.linkedin.android.shaky.EmailShakeDelegate;
 import com.linkedin.android.shaky.Shaky;
 
@@ -23,9 +24,17 @@ import com.linkedin.android.shaky.Shaky;
  * Hello world example.
  */
 public class ShakyApplication extends Application {
+
+    private Shaky shaky;
+
     @Override
     public void onCreate() {
         super.onCreate();
-        Shaky.with(this, new EmailShakeDelegate("hello@world.com"));
+        shaky = Shaky.with(this, new EmailShakeDelegate("hello@world.com"));
+    }
+
+    @NonNull
+    public Shaky getShaky() {
+        return shaky;
     }
 }

--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -18,9 +18,7 @@ package com.linkedin.android.shaky.app;
 import android.app.Activity;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.view.Gravity;
-import android.view.ViewGroup.LayoutParams;
-import android.widget.TextView;
+import android.view.View;
 
 import java.util.Random;
 
@@ -31,15 +29,19 @@ public class ShakyDemo extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_demo);
 
-        TextView tv = new TextView(this);
-        tv.setGravity(Gravity.CENTER);
-        tv.setText(R.string.shake_me);
+        View tv = findViewById(R.id.demo_background);
 
         Random random = new Random();
         int color = Color.rgb(random.nextInt(RGB_MAX), random.nextInt(RGB_MAX), random.nextInt(RGB_MAX));
         tv.setBackgroundColor(color);
 
-        setContentView(tv, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+        findViewById(R.id.demo_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ((ShakyApplication) getApplication()).getShaky().startFeedbackFlow();
+            }
+        });
     }
 }

--- a/shaky-sample/src/main/res/layout/activity_demo.xml
+++ b/shaky-sample/src/main/res/layout/activity_demo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout android:id="@+id/demo_background"
+              xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/demo_textview"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/shake_me"/>
+
+    <Button
+        android:id="@+id/demo_button"
+        style="?attr/borderlessButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/manual_feedback_trigger"/>
+
+</LinearLayout>

--- a/shaky-sample/src/main/res/values/strings.xml
+++ b/shaky-sample/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name" translatable="false">Shaky</string>
     <string name="shake_me" translatable="false">Shake me!</string>
+    <string name="manual_feedback_trigger" translatable="false">Manually start feedback</string>
 </resources>

--- a/shaky/src/main/java/com/linkedin/android/shaky/LifecycleCallbacks.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/LifecycleCallbacks.java
@@ -17,7 +17,6 @@ package com.linkedin.android.shaky;
 
 import android.app.Activity;
 import android.app.Application;
-import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
@@ -25,8 +24,8 @@ class LifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
 
     private final Shaky shaky;
 
-    LifecycleCallbacks(@NonNull Context appContext, @NonNull ShakeDelegate delegate) {
-        shaky = new Shaky(appContext, delegate);
+    LifecycleCallbacks(@NonNull Shaky shaky) {
+        this.shaky = shaky;
     }
 
     @Override

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -16,7 +16,6 @@
 package com.linkedin.android.shaky;
 
 import android.app.Activity;
-import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 
 /**
@@ -25,6 +24,7 @@ import android.support.annotation.WorkerThread;
  * This class contains methods that apps can override to customize the behavior of Shaky.
  */
 public abstract class ShakeDelegate {
+
     /**
      * @return true if shake detection should be enabled, false otherwise
      */


### PR DESCRIPTION
Consumers may want to create their own UI for starting
the feedback flow, without requiring the user to shake
their device. With this change, we now expose the
Shaky class to users of the library, but with only one
public method, startFeedbackFlow().

This also updates the demo app to show how to use the
new API.

Fixes #6