### PR TITLE
Fix #18: Basic support for sensitivity levels

### DIFF
--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    compile 'com.squareup:seismic:1.0.1'
+    compile 'com.squareup:seismic:1.0.2'
     compile "com.android.support:appcompat-v7:$supportLibrariesVersion"
     compile "com.android.support:recyclerview-v7:$supportLibrariesVersion"
     compile "com.android.support:support-v4:$supportLibrariesVersion"

--- a/shaky/src/main/java/com/linkedin/android/shaky/EmailShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/EmailShakeDelegate.java
@@ -51,7 +51,7 @@ public class EmailShakeDelegate extends ShakeDelegate {
     /**
      * Optionally override sensitivityLevel to one of ShakeDelegate.SENSITIVITY_*
      */
-    public void setSensitivityLevel(int newLevel) {
+    public void setSensitivityLevel(@ShakeDelegate.SensitivityLevel int newLevel) {
         sensitivityLevel = newLevel;
     }
 

--- a/shaky/src/main/java/com/linkedin/android/shaky/EmailShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/EmailShakeDelegate.java
@@ -55,7 +55,6 @@ public class EmailShakeDelegate extends ShakeDelegate {
         sensitivityLevel = newLevel;
     }
 
-
     /**
      * Creates the email {@link Intent} and attaches all attachments.
      * Subclasses should override this method to customize the email Intent.

--- a/shaky/src/main/java/com/linkedin/android/shaky/EmailShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/EmailShakeDelegate.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
  */
 public class EmailShakeDelegate extends ShakeDelegate {
     private String[] to;
+    private int sensitivityLevel = ShakeDelegate.SENSITIVITY_MEDIUM;
 
     public EmailShakeDelegate(@NonNull String[] to) {
         this.to = to;
@@ -41,6 +42,19 @@ public class EmailShakeDelegate extends ShakeDelegate {
     public final void submit(@NonNull Activity activity, @NonNull Result result) {
         activity.startActivity(onSubmit(result));
     }
+
+    @Override
+    public int getSensitivityLevel() {
+        return sensitivityLevel;
+    }
+
+    /**
+     * Optionally override sensitivityLevel to one of ShakeDelegate.SENSITIVITY_*
+     */
+    public void setSensitivityLevel(int newLevel) {
+        sensitivityLevel = newLevel;
+    }
+
 
     /**
      * Creates the email {@link Intent} and attaches all attachments.

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -17,6 +17,10 @@ package com.linkedin.android.shaky;
 
 import android.app.Activity;
 import android.support.annotation.WorkerThread;
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * Entry point into this API.
@@ -24,6 +28,13 @@ import android.support.annotation.WorkerThread;
  * This class contains methods that apps can override to customize the behavior of Shaky.
  */
 public abstract class ShakeDelegate {
+    @IntDef({
+            SENSITIVITY_LIGHT,
+            SENSITIVITY_MEDIUM,
+            SENSITIVITY_HARD
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface SensitivityLevel {}
 
     public static final int SENSITIVITY_LIGHT  = 22;
     public static final int SENSITIVITY_MEDIUM = 23;
@@ -39,6 +50,7 @@ public abstract class ShakeDelegate {
     /**
      * @return desired sensitivity level, defaults to 'medium'
      */
+    @SensitivityLevel
     public int getSensitivityLevel() {
         return SENSITIVITY_MEDIUM;
     }

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -36,9 +36,9 @@ public abstract class ShakeDelegate {
     @Retention(RetentionPolicy.SOURCE)
     public @interface SensitivityLevel {}
 
-    public static final int SENSITIVITY_LIGHT  = 22;
+    public static final int SENSITIVITY_LIGHT = 22;
     public static final int SENSITIVITY_MEDIUM = 23;
-    public static final int SENSITIVITY_HARD   = 24;
+    public static final int SENSITIVITY_HARD = 24;
 
     /**
      * @return true if shake detection should be enabled, false otherwise

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -25,11 +25,22 @@ import android.support.annotation.WorkerThread;
  */
 public abstract class ShakeDelegate {
 
+    public static final int SENSITIVITY_LIGHT  = 22;
+    public static final int SENSITIVITY_MEDIUM = 23;
+    public static final int SENSITIVITY_HARD   = 24;
+
     /**
      * @return true if shake detection should be enabled, false otherwise
      */
     public boolean isEnabled() {
         return true;
+    }
+
+    /**
+     * @return desired sensitivity level, defaults to 'medium'
+     */
+    public int getSensitivityLevel() {
+        return SENSITIVITY_MEDIUM;
     }
 
     /**

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -61,7 +61,7 @@ public class Shaky implements ShakeDetector.Listener {
         this.delegate = delegate;
         shakeDetector = new ShakeDetector(this);
 
-        shakeDetector.setSensitivity( getDetectorSensitivityLevel() );
+        shakeDetector.setSensitivity(getDetectorSensitivityLevel());
 
         IntentFilter filter = new IntentFilter();
         filter.addAction(SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW);
@@ -248,10 +248,12 @@ public class Shaky implements ShakeDetector.Listener {
     public int getDetectorSensitivityLevel() {
         int delegateLevel = delegate.getSensitivityLevel();
 
-        if ( delegateLevel == ShakeDelegate.SENSITIVITY_LIGHT ) return ShakeDetector.SENSITIVITY_LIGHT;
-        if ( delegateLevel == ShakeDelegate.SENSITIVITY_HARD  ) return ShakeDetector.SENSITIVITY_HARD;
-
-        return ShakeDetector.SENSITIVITY_MEDIUM;
+        if (delegateLevel == ShakeDelegate.SENSITIVITY_LIGHT) {
+            return ShakeDetector.SENSITIVITY_LIGHT;
+        } else if (delegateLevel == ShakeDelegate.SENSITIVITY_HARD) {
+            return ShakeDetector.SENSITIVITY_HARD;
+        } else {
+            return ShakeDetector.SENSITIVITY_MEDIUM;
+        }
     }
-
 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -61,6 +61,8 @@ public class Shaky implements ShakeDetector.Listener {
         this.delegate = delegate;
         shakeDetector = new ShakeDetector(this);
 
+        shakeDetector.setSensitivity( getDetectorSensitivityLevel() );
+
         IntentFilter filter = new IntentFilter();
         filter.addAction(SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW);
         filter.addAction(FeedbackActivity.ACTION_END_FEEDBACK_FLOW);
@@ -241,4 +243,15 @@ public class Shaky implements ShakeDetector.Listener {
 
         return result;
     }
+
+    @VisibleForTesting
+    public int getDetectorSensitivityLevel() {
+        int delegateLevel = delegate.getSensitivityLevel();
+
+        if ( delegateLevel == ShakeDelegate.SENSITIVITY_LIGHT ) return ShakeDetector.SENSITIVITY_LIGHT;
+        if ( delegateLevel == ShakeDelegate.SENSITIVITY_HARD  ) return ShakeDetector.SENSITIVITY_HARD;
+
+        return ShakeDetector.SENSITIVITY_MEDIUM;
+    }
+
 }

--- a/shaky/src/test/java/com/linkedin/android/shaky/ShakyShould.java
+++ b/shaky/src/test/java/com/linkedin/android/shaky/ShakyShould.java
@@ -22,7 +22,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import com.squareup.seismic.ShakeDetector;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -48,6 +50,7 @@ public class ShakyShould {
         when(activity.getFragmentManager()).thenReturn(fragmentManager);
         when(activity.getApplicationContext()).thenReturn(activity);
         when(activity.getMainLooper()).thenReturn(Looper.getMainLooper());
+        when(delegate.getSensitivityLevel()).thenReturn(ShakeDelegate.SENSITIVITY_LIGHT);
 
         shaky = new Shaky(activity, delegate);
         shaky.setActivity(activity);
@@ -70,5 +73,10 @@ public class ShakyShould {
         FeedbackActivity feedbackActivity = new FeedbackActivity();
         shaky.setActivity(feedbackActivity);
         assertFalse(shaky.canStartFeedbackFlow());
+    }
+
+    @Test
+    public void respectDelegateSensitivityLevel() {
+        assertEquals(shaky.getDetectorSensitivityLevel(), ShakeDetector.SENSITIVITY_LIGHT);
     }
 }


### PR DESCRIPTION
Very rudimentary, but should address the concerns in #18 . As per the discussion in that thread, anything more sophisticated is probably overkill at this stage.

I also threw in a basic test case, but there isn't a ton of logic to begin with.

Note: this requires a minor version bump on Seismic. The new version is still from 2015, so probably not very risky, but wanted to point that out.
