### PR TITLE
Made it possible to test the maven publication locally

### DIFF
--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -111,6 +111,14 @@ publishing {
                     }
                 }
             }
+
+            //Makes it useful to debug locally and inspect the maven publication
+            //To see the maven publication files in 'build/repo' run './gradlew publish'            
+            repositories {
+                maven {
+                    url = "$buildDir/repo"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Made it possible to test the maven publication locally. We are using this method to do dependency testing at LinkedIn.