### PR TITLE
Made it possible to test the maven publication locally.

### DIFF
--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -109,6 +109,13 @@ publishing {
                     }
                 }
             }
+
+            //For local debugging of maven publications run './gradlew publish' and check 'build/repo'
+            repositories {
+                maven {
+                    url = "$rootProject.buildDir/repo"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
We are using this method to do dependency testing at LinkedIn. It is also useful to review and inspect maven artifacts / poms.