### PR TITLE
adding the option to customize the send icon

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -28,6 +28,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.annotation.IdRes;
 
 /**
  * The main activity used capture and send feedback.
@@ -40,18 +41,22 @@ public class FeedbackActivity extends AppCompatActivity {
     static final String MESSAGE = "message";
     static final String TITLE = "title";
     static final String USER_DATA = "userData";
+    static final String SEND_ICON = "sendIcon";
 
     private Uri imageUri;
     private @FeedbackItem.FeedbackType int feedbackType;
     private Bundle userData;
+    private @IdRes int sendIcon;
 
     @NonNull
     public static Intent newIntent(@NonNull Context context,
                                    @Nullable Uri screenshotUri,
-                                   @Nullable Bundle userData) {
+                                   @Nullable Bundle userData,
+                                   @Nullable @IdRes int sendIcon) {
         Intent intent = new Intent(context, FeedbackActivity.class);
         intent.putExtra(SCREENSHOT_URI, screenshotUri);
         intent.putExtra(USER_DATA, userData);
+        intent.putExtra(SEND_ICON, sendIcon);
         return intent;
     }
 
@@ -63,6 +68,7 @@ public class FeedbackActivity extends AppCompatActivity {
 
         imageUri = getIntent().getParcelableExtra(SCREENSHOT_URI);
         userData = getIntent().getBundleExtra(USER_DATA);
+        sendIcon = getIntent().getIntExtra(SEND_ICON, FormFragment.DEFAULT_SUBMIT_ICON);
 
         if (savedInstanceState == null) {
             getSupportFragmentManager()
@@ -110,7 +116,7 @@ public class FeedbackActivity extends AppCompatActivity {
     private void startFormFragment(@FeedbackItem.FeedbackType int feedbackType) {
         String title = getString(getTitleResId(feedbackType));
         String hint = getString(getHintResId(feedbackType));
-        changeToFragment(FormFragment.newInstance(title, hint, imageUri));
+        changeToFragment(FormFragment.newInstance(title, hint, imageUri, sendIcon));
     }
 
     /**

--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -28,7 +28,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.annotation.IdRes;
+import androidx.annotation.MenuRes;
 
 /**
  * The main activity used capture and send feedback.
@@ -41,22 +41,22 @@ public class FeedbackActivity extends AppCompatActivity {
     static final String MESSAGE = "message";
     static final String TITLE = "title";
     static final String USER_DATA = "userData";
-    static final String SEND_ICON = "sendIcon";
+    static final String RES_MENU = "resMenu";
 
     private Uri imageUri;
     private @FeedbackItem.FeedbackType int feedbackType;
     private Bundle userData;
-    private @IdRes int sendIcon;
+    private @MenuRes int resMenu;
 
     @NonNull
     public static Intent newIntent(@NonNull Context context,
                                    @Nullable Uri screenshotUri,
                                    @Nullable Bundle userData,
-                                   @Nullable @IdRes int sendIcon) {
+                                   @Nullable @MenuRes int resMenu) {
         Intent intent = new Intent(context, FeedbackActivity.class);
         intent.putExtra(SCREENSHOT_URI, screenshotUri);
         intent.putExtra(USER_DATA, userData);
-        intent.putExtra(SEND_ICON, sendIcon);
+        intent.putExtra(RES_MENU, resMenu);
         return intent;
     }
 
@@ -68,7 +68,7 @@ public class FeedbackActivity extends AppCompatActivity {
 
         imageUri = getIntent().getParcelableExtra(SCREENSHOT_URI);
         userData = getIntent().getBundleExtra(USER_DATA);
-        sendIcon = getIntent().getIntExtra(SEND_ICON, FormFragment.DEFAULT_SUBMIT_ICON);
+        resMenu = getIntent().getIntExtra(RES_MENU, FormFragment.DEFAULT_MENU);
 
         if (savedInstanceState == null) {
             getSupportFragmentManager()
@@ -116,7 +116,7 @@ public class FeedbackActivity extends AppCompatActivity {
     private void startFormFragment(@FeedbackItem.FeedbackType int feedbackType) {
         String title = getString(getTitleResId(feedbackType));
         String hint = getString(getHintResId(feedbackType));
-        changeToFragment(FormFragment.newInstance(title, hint, imageUri, sendIcon));
+        changeToFragment(FormFragment.newInstance(title, hint, imageUri, resMenu));
     }
 
     /**

--- a/shaky/src/main/java/com/linkedin/android/shaky/FormFragment.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FormFragment.java
@@ -19,6 +19,8 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -26,12 +28,13 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import android.view.LayoutInflater;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
-import androidx.annotation.IdRes;
+import androidx.annotation.MenuRes;
 
 /**
  * The main form used to send feedback.
@@ -41,22 +44,23 @@ public class FormFragment extends Fragment {
     static final String ACTION_SUBMIT_FEEDBACK = "ActionSubmitFeedback";
     static final String ACTION_EDIT_IMAGE = "ActionEditImage";
     static final String EXTRA_USER_MESSAGE = "ExtraUserMessage";
-    static final int DEFAULT_SUBMIT_ICON = R.id.action_submit;
+    // If you want to change the send icon, you must create a new menu
+    static final @MenuRes int DEFAULT_MENU = R.menu.shaky_feedback_activity_actions;
 
     private static final String KEY_SCREENSHOT_URI = "ScreenshotUri";
     private static final String KEY_TITLE = "title";
     private static final String KEY_HINT = "hint";
-    private static final String KEY_SEND_ICON = "sendIcon";
+    private static final String KEY_MENU = "menu";
 
     public static FormFragment newInstance(@NonNull String title,
                                            @NonNull String hint,
                                            @Nullable Uri screenshotUri,
-                                           @Nullable @IdRes int sendIcon) {
+                                           @Nullable @MenuRes int menu) {
         Bundle args = new Bundle();
         args.putParcelable(KEY_SCREENSHOT_URI, screenshotUri);
         args.putString(KEY_TITLE, title);
         args.putString(KEY_HINT, hint);
-        args.putInt(KEY_SEND_ICON, sendIcon);
+        args.putInt(KEY_MENU, menu);
 
         FormFragment fragment = new FormFragment();
         fragment.setArguments(args);
@@ -78,7 +82,7 @@ public class FormFragment extends Fragment {
         ImageView attachmentImageView = (ImageView) view.findViewById(R.id.shaky_form_attachment);
 
         Uri screenshotUri = getArguments().getParcelable(KEY_SCREENSHOT_URI);
-        int sendIconResource = getArguments().getInt(KEY_SEND_ICON);
+        int sendIconResource = getArguments().getInt(KEY_MENU);
 
         String title = getArguments().getString(KEY_TITLE);
         toolbar.setTitle(title);

--- a/shaky/src/main/java/com/linkedin/android/shaky/FormFragment.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FormFragment.java
@@ -31,6 +31,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
+import androidx.annotation.IdRes;
 
 /**
  * The main form used to send feedback.
@@ -39,20 +40,23 @@ public class FormFragment extends Fragment {
 
     static final String ACTION_SUBMIT_FEEDBACK = "ActionSubmitFeedback";
     static final String ACTION_EDIT_IMAGE = "ActionEditImage";
-
     static final String EXTRA_USER_MESSAGE = "ExtraUserMessage";
+    static final int DEFAULT_SUBMIT_ICON = R.id.action_submit;
 
     private static final String KEY_SCREENSHOT_URI = "ScreenshotUri";
     private static final String KEY_TITLE = "title";
     private static final String KEY_HINT = "hint";
+    private static final String KEY_SEND_ICON = "sendIcon";
 
     public static FormFragment newInstance(@NonNull String title,
                                            @NonNull String hint,
-                                           @Nullable Uri screenshotUri) {
+                                           @Nullable Uri screenshotUri,
+                                           @Nullable @IdRes int sendIcon) {
         Bundle args = new Bundle();
         args.putParcelable(KEY_SCREENSHOT_URI, screenshotUri);
         args.putString(KEY_TITLE, title);
         args.putString(KEY_HINT, hint);
+        args.putInt(KEY_SEND_ICON, sendIcon);
 
         FormFragment fragment = new FormFragment();
         fragment.setArguments(args);
@@ -74,12 +78,13 @@ public class FormFragment extends Fragment {
         ImageView attachmentImageView = (ImageView) view.findViewById(R.id.shaky_form_attachment);
 
         Uri screenshotUri = getArguments().getParcelable(KEY_SCREENSHOT_URI);
+        int sendIconResource = getArguments().getInt(KEY_SEND_ICON);
 
         String title = getArguments().getString(KEY_TITLE);
         toolbar.setTitle(title);
         toolbar.setNavigationIcon(R.drawable.ic_arrow_back_white_24dp);
         toolbar.setNavigationOnClickListener(createNavigationClickListener());
-        toolbar.inflateMenu(R.menu.shaky_feedback_activity_actions);
+        toolbar.inflateMenu(sendIconResource);
         toolbar.setOnMenuItemClickListener(createMenuClickListener(messageEditText));
 
         String hint = getArguments().getString(KEY_HINT);

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -20,7 +20,6 @@ import android.app.Activity;
 import androidx.annotation.MenuRes;
 import androidx.annotation.WorkerThread;
 import androidx.annotation.IntDef;
-import androidx.annotation.IdRes;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -18,6 +18,7 @@ package com.linkedin.android.shaky;
 import android.app.Activity;
 import androidx.annotation.WorkerThread;
 import androidx.annotation.IntDef;
+import androidx.annotation.IdRes;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -42,6 +43,9 @@ public abstract class ShakeDelegate {
 
     @SensitivityLevel
     private static int sensitivityLevel = SENSITIVITY_MEDIUM;
+    // Allows user to customize the send icon at the end
+    @IdRes protected int sendIcon;
+
     /**
      * @return true if shake detection should be enabled, false otherwise
      */

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -16,6 +16,8 @@
 package com.linkedin.android.shaky;
 
 import android.app.Activity;
+
+import androidx.annotation.MenuRes;
 import androidx.annotation.WorkerThread;
 import androidx.annotation.IntDef;
 import androidx.annotation.IdRes;
@@ -43,8 +45,10 @@ public abstract class ShakeDelegate {
 
     @SensitivityLevel
     private static int sensitivityLevel = SENSITIVITY_MEDIUM;
-    // Allows user to customize the send icon at the end
-    @IdRes protected int sendIcon;
+    /** Allows user to customize the send icon at the end. Needs to be the menu itself because you cannot
+     * change the send icon unless you send in a new menu, Also needs a value or else it crashes
+     */
+    @MenuRes protected int resMenu = FormFragment.DEFAULT_MENU;
 
     /**
      * @return true if shake detection should be enabled, false otherwise

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -249,7 +249,7 @@ public class Shaky implements ShakeDetector.Listener {
      * Launches the main feedback activity with the bundle extra data.
      */
     private void startFeedbackActivity(@NonNull Result result) {
-        Intent intent = FeedbackActivity.newIntent(activity, result.getScreenshotUri(), result.getData());
+        Intent intent = FeedbackActivity.newIntent(activity, result.getScreenshotUri(), result.getData(), delegate.sendIcon);
         activity.startActivity(intent);
     }
 

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -249,7 +249,7 @@ public class Shaky implements ShakeDetector.Listener {
      * Launches the main feedback activity with the bundle extra data.
      */
     private void startFeedbackActivity(@NonNull Result result) {
-        Intent intent = FeedbackActivity.newIntent(activity, result.getScreenshotUri(), result.getData(), delegate.sendIcon);
+        Intent intent = FeedbackActivity.newIntent(activity, result.getScreenshotUri(), result.getData(), delegate.resMenu);
         activity.startActivity(intent);
     }
 


### PR DESCRIPTION
Received feedback of Shaky that the arrow icon at the end of the shaky process looks it will send the feedback but actually just goes to the next page. To avoid the confusion, these changes allow that arrow icon (send icon) to be customizable if needed