### PR TITLE
Add ability to customize title and message of shaky dialog

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/SendFeedbackDialog.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/SendFeedbackDialog.java
@@ -24,6 +24,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.view.View;
 
+import android.widget.TextView;
 import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.NonNull;
@@ -38,6 +39,8 @@ public class SendFeedbackDialog extends DialogFragment {
     public static final String ACTION_START_FEEDBACK_FLOW = "StartFeedbackFlow";
     public static final String ACTION_DIALOG_DISMISSED_BY_USER = "DialogDismissedByUser";
     public static final String SHOULD_DISPLAY_SETTING_UI = "ShouldDisplaySettingUI";
+    public static final String CUSTOM_TITLE = "CustomTitle";
+    public static final String CUSTOM_MESSAGE = "CustomMessage";
 
     private static final long DISMISS_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5);
 
@@ -54,8 +57,23 @@ public class SendFeedbackDialog extends DialogFragment {
 
         View popupView = View.inflate(getActivity().getApplicationContext(),
                                       R.layout.shaky_popup, null);
-        builder.setView(popupView);
 
+        String customTitle = getArguments().getString(CUSTOM_TITLE);
+        if (customTitle != null) {
+            TextView titleView = (TextView) popupView.findViewById(R.id.shaky_dialog_title);
+            if (titleView != null) {
+                titleView.setText(customTitle);
+            }
+        }
+        String customMessage = getArguments().getString(CUSTOM_MESSAGE);
+        if (customMessage != null) {
+            TextView messageView = (TextView) popupView.findViewById(R.id.shaky_dialog_message);
+            if (messageView != null) {
+                messageView.setText(customMessage);
+            }
+        }
+
+        builder.setView(popupView);
         builder.setPositiveButton(R.string.shaky_dialog_positive, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import androidx.annotation.IntDef;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import java.lang.annotation.Retention;
@@ -62,6 +63,24 @@ public abstract class ShakeDelegate {
      */
     public boolean shouldShowSettingsUI() {
         return false;
+    }
+
+    /**
+     * @return the title of the dialog that appears on shake, or null if the default title should be
+     * used
+     */
+    @Nullable
+    public String getDialogTitle() {
+        return null;
+    }
+
+    /**
+     * @return the message of the dialog that appears on shake, or null if the default message should
+     * be used
+     */
+    @Nullable
+    public String getDialogMessage() {
+        return null;
     }
 
     /**

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -173,6 +173,12 @@ public class Shaky implements ShakeDetector.Listener {
         }
 
         Bundle arguments = new Bundle();
+        if (delegate.getDialogTitle() != null) {
+            arguments.putString(SendFeedbackDialog.CUSTOM_TITLE, delegate.getDialogTitle());
+        }
+        if (delegate.getDialogMessage() != null) {
+            arguments.putString(SendFeedbackDialog.CUSTOM_MESSAGE, delegate.getDialogMessage());
+        }
         arguments.putBoolean(SendFeedbackDialog.SHOULD_DISPLAY_SETTING_UI, delegate.shouldShowSettingsUI());
         arguments.putInt(ShakySettingDialog.SHAKY_CURRENT_SENSITIVITY, delegate.getSensitivityLevel());
         SendFeedbackDialog sendFeedbackDialog = new SendFeedbackDialog();

--- a/shaky/src/main/res/layout-v17/shaky_popup.xml
+++ b/shaky/src/main/res/layout-v17/shaky_popup.xml
@@ -45,7 +45,8 @@
             android:textAlignment="textStart"
             android:paddingBottom="@dimen/title_padding"
             android:textSize="@dimen/title_textsize"
-            android:textColor="@color/title"/>
+            android:textColor="@color/title"
+            android:id="@+id/shaky_dialog_title"/>
 
         <TextView
             android:layout_width="wrap_content"
@@ -54,7 +55,8 @@
             android:gravity="start"
             android:textAlignment="textStart"
             android:textSize="@dimen/content_textsize"
-            android:textColor="@color/content"/>
+            android:textColor="@color/content"
+            android:id="@+id/shaky_dialog_message"/>
 
     </LinearLayout>
 

--- a/shaky/src/main/res/layout/shaky_popup.xml
+++ b/shaky/src/main/res/layout/shaky_popup.xml
@@ -44,7 +44,8 @@
             android:gravity="start"
             android:paddingBottom="@dimen/title_padding"
             android:textSize="@dimen/title_textsize"
-            android:textColor="@color/title"/>
+            android:textColor="@color/title"
+            android:id="@+id/shaky_dialog_title"/>
 
         <TextView
             android:layout_width="wrap_content"
@@ -52,7 +53,8 @@
             android:text="@string/shaky_dialog_message"
             android:gravity="start"
             android:textSize="@dimen/content_textsize"
-            android:textColor="@color/content"/>
+            android:textColor="@color/content"
+            android:id="@+id/shaky_dialog_message"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
The shake delegate gets 2 additional methods for configuring the title and message of the dialog that shows when triggering feedback.