### PR TITLE
Fixing alert dialog styling capability in material theme

### DIFF
--- a/shaky-sample/src/main/res/values/styles.xml
+++ b/shaky-sample/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- LinkedIn Color theme -->
         <!-- https://brand.linkedin.com/visual-identity/color-palettes -->
         <item name="colorAccent">@color/blue</item>

--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     api 'com.squareup:seismic:1.0.2'
     implementation 'com.jraska:falcon:2.1.1'
     implementation "androidx.appcompat:appcompat:1.0.0"
+    implementation "com.google.android.material:material:1.1.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "androidx.annotation:annotation:1.0.0"

--- a/shaky/src/main/res/values/shaky_styles.xml
+++ b/shaky/src/main/res/values/shaky_styles.xml
@@ -69,6 +69,7 @@
         <!-- AlertDialog -->
         <item name="shakyAlertDialogTheme">@style/ShakyBaseAlertDialogTheme</item>
         <item name="alertDialogTheme">?attr/shakyAlertDialogTheme</item>
+        <item name="materialAlertDialogTheme">?attr/shakyAlertDialogTheme</item>
     </style>
 
     <style name="ShakyBasePopupTheme" parent="Theme.AppCompat.Light.Dialog.Alert">


### PR DESCRIPTION
Currently, custom styling on alert dialogs can only be applied to apps using AppCompat base themes. This patch fills the gap by setting the attribute "materialAlertDialogTheme" in Shaky's base theme.

Tested manually by verifying that the sample app works with material theme.