### PR TITLE
Update seismic and other libraries and change to use sensor delay normal

### DIFF
--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -26,15 +26,15 @@ android {
 }
 
 dependencies {
-    api 'com.squareup:seismic:1.0.2'
+    api 'com.squareup:seismic:1.0.3'
     implementation 'com.jraska:falcon:2.1.1'
-    implementation "androidx.appcompat:appcompat:1.0.0"
-    implementation "com.google.android.material:material:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "com.google.android.material:material:1.4.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation "androidx.annotation:annotation:1.0.0"
+    implementation "androidx.annotation:annotation:1.2.0"
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
-    testImplementation 'org.robolectric:robolectric:3.7.1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:3.11.2'
+    testImplementation 'org.robolectric:robolectric:4.5.1'
 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -152,7 +152,7 @@ public class Shaky implements ShakeDetector.Listener {
             return;
         }
 
-        shakeDetector.start((SensorManager) activity.getSystemService(Context.SENSOR_SERVICE));
+        shakeDetector.start((SensorManager) activity.getSystemService(Context.SENSOR_SERVICE), SensorManager.SENSOR_DELAY_NORMAL);
     }
 
     /**


### PR DESCRIPTION
With Seismic allowing setting the sensor sampling rate so as to prevent requiring another user permission in Android 12. Updating shaky to use normal sensor sampling rate as opposed to the fastest sensor sampling rate.