### PR TITLE
Updated Falcon Library version 

### DIFF
--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     api 'com.squareup:seismic:1.0.3'
-    implementation 'com.jraska:falcon:2.1.1'
+    implementation 'com.jraska:falcon:2.2.0'
     implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "com.google.android.material:material:1.1.0"
     implementation "androidx.recyclerview:recyclerview:1.2.1"


### PR DESCRIPTION
TL;DR: old version no longer works due to jcenter shutdown.

Jcenter completely shutdown and the version 2.1.1 is can no longer be fetched. 
Falcon has moved maven from v 2.2.0 
[v2.2.0](https://github.com/jraska/Falcon/releases/tag/2.2.0)
