### PR TITLE
Add support for showing and selecting sub views

### DIFF
--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -41,5 +41,5 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'
-    testImplementation 'org.robolectric:robolectric:4.6.1'
+    testImplementation 'org.robolectric:robolectric:4.9.2'
 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
@@ -116,40 +116,33 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
     @WorkerThread
     private ArrayList<Subview> collectSubviewsIfNeeded(@Nullable String defaultOwnerEmail) {
         View contentView = activity.findViewById(android.R.id.content);
-        ArrayList<Subview> subViews = new ArrayList<>();
-        identifyVisibleSubviews(contentView, subViews, defaultOwnerEmail);
-        return subViews;
+        return identifyVisibleSubviews(contentView, defaultOwnerEmail);
     }
 
     /**
      * Goes through the view hierarchy of the given view, identifies the child views and
      * adds them to the subviews list
      */
-    private void identifyVisibleSubviews(@Nullable View view, @NonNull List<Subview> subViews, @Nullable String defaultEmail) {
+    private ArrayList<Subview> identifyVisibleSubviews(@Nullable View view, @Nullable String defaultEmail) {
+        ArrayList<Subview> subViews = new ArrayList<>();
+
         if (view == null) {
-            return;
+            return subViews;
         }
 
         if (view instanceof ViewGroup) {
             ViewGroup viewGroup = (ViewGroup) view;
-            int childCount = viewGroup.getChildCount();
-            if (childCount == 0) {
-                // Check if the leaf view is visible on screen
-                Subview subView = createSubview(view, defaultEmail);
-                if (subView != null) {
-                    subViews.add(subView);
-                }
-            } else {
-                for (int i = 0; i < childCount; i++) {
-                    identifyVisibleSubviews(viewGroup.getChildAt(i), subViews, defaultEmail);
-                }
-            }
-        } else {
-            Subview subView = createSubview(view, defaultEmail);
-            if (subView != null) {
-                subViews.add(subView);
+            for (int i = 0; i < viewGroup.getChildCount(); i++) {
+                subViews.addAll(identifyVisibleSubviews(viewGroup.getChildAt(i), defaultEmail));
             }
         }
+
+        Subview subView = createSubview(view, defaultEmail);
+        if (subView != null) {
+            subViews.add(subView);
+        }
+
+        return subViews;
     }
 
     /**

--- a/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 LinkedIn Corp.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,14 +18,22 @@ package com.linkedin.android.shaky;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.Rect;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
-import android.util.Log;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Background task to collect user data. Used with {@link CollectDataDialog}.
@@ -35,6 +43,9 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
     private static final String TAG = CollectDataTask.class.getSimpleName();
 
     private static final String SCREENSHOT_DIRECTORY = "/screenshots";
+    private static final String DEFAULT_OWNER_EMAIL = "defaultOwnerEmail";
+
+    private static final int RGB_MAX = 256;
 
     private final Activity activity;
     private final ShakeDelegate delegate;
@@ -46,6 +57,16 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
         this.activity = activity;
         this.delegate = delegate;
         this.callback = callback;
+    }
+
+    @Nullable
+    @WorkerThread
+    private static String getScreenshotDirectoryRoot(@NonNull Context context) {
+        File filesDir = context.getFilesDir();
+        if (filesDir == null) {
+            return null;
+        }
+        return filesDir.getAbsolutePath() + SCREENSHOT_DIRECTORY;
     }
 
     @Override
@@ -77,6 +98,7 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
         Result result = new Result();
         result.setScreenshotUri(screenshotUri);
         delegate.collectData(activity, result);
+        result.setSubViews(collectSubviewsIfNeeded(result.getData().getString(DEFAULT_OWNER_EMAIL)));
         return result;
     }
 
@@ -87,14 +109,87 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
         callback.onDataReady(result);
     }
 
-    @Nullable
+    /**
+     * For the root view, identifies the subviews and its owners and returns them if needed to
+     * be shown in the selection screen
+     */
     @WorkerThread
-    private static String getScreenshotDirectoryRoot(@NonNull Context context) {
-        File filesDir = context.getFilesDir();
-        if (filesDir == null) {
+    private ArrayList<Subview> collectSubviewsIfNeeded(@Nullable String defaultOwnerEmail) {
+        View contentView = activity.findViewById(android.R.id.content);
+        ArrayList<Subview> subViews = new ArrayList<>();
+        identifyVisibleSubviews(contentView, subViews, defaultOwnerEmail);
+        return subViews;
+    }
+
+    /**
+     * Goes through the view hierarchy of the given view, identifies the child views and
+     * adds them to the subviews list
+     */
+    private void identifyVisibleSubviews(@Nullable View view, @NonNull List<Subview> subViews, @Nullable String defaultEmail) {
+        if (view == null) {
+            return;
+        }
+
+        if (view instanceof ViewGroup) {
+            ViewGroup viewGroup = (ViewGroup) view;
+            int childCount = viewGroup.getChildCount();
+            if (childCount == 0) {
+                // Check if the leaf view is visible on screen
+                Subview subView = createSubview(view, defaultEmail);
+                if (subView != null) {
+                    subViews.add(subView);
+                }
+            } else {
+                for (int i = 0; i < childCount; i++) {
+                    identifyVisibleSubviews(viewGroup.getChildAt(i), subViews, defaultEmail);
+                }
+            }
+        } else {
+            Subview subView = createSubview(view, defaultEmail);
+            if (subView != null) {
+                subViews.add(subView);
+            }
+        }
+    }
+
+    /**
+     * Creates a new subview object for the child view by identifying the bounds and owner of the view.
+     */
+    @Nullable
+    private Subview createSubview(@NonNull View view, @Nullable String defaultEmail) {
+        Object ownerTag = view.getTag(R.id.shaky_owner_tag);
+        String owner = ownerTag != null ? String.valueOf(ownerTag) : null;
+        if (!shouldShowSelection(owner, defaultEmail)) {
             return null;
         }
-        return filesDir.getAbsolutePath() + SCREENSHOT_DIRECTORY;
+
+        // Check if the view is visible on screen
+        Rect rect = new Rect();
+        if (!view.getGlobalVisibleRect(rect)) {
+            return null;
+        }
+
+        Random random = new Random();
+        int color = Color.rgb(random.nextInt(RGB_MAX), random.nextInt(RGB_MAX), random.nextInt(RGB_MAX));
+        return new Subview(rect, owner, color, false);
+    }
+
+    /**
+     * Returns if the screen is eligible to show the sub views in the screens
+     * <p>
+     * We would only show the sub views if there is a default owner and if there is at least
+     * one subview which has a different owner than the default owner.
+     */
+    private boolean shouldShowSelection(@Nullable String ownerEmail, @Nullable String defaultEmail) {
+        if (ownerEmail == null) {
+            return false;
+        }
+
+        if (defaultEmail == null) {
+            return true;
+        }
+
+        return !ownerEmail.equals(defaultEmail);
     }
 
     interface Callback {

--- a/shaky/src/main/java/com/linkedin/android/shaky/Result.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Result.java
@@ -17,12 +17,11 @@ package com.linkedin.android.shaky;
 
 import android.net.Uri;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Wrapper class for the data collected.
@@ -102,11 +101,7 @@ public class Result {
     @Nullable
     public ArrayList<Subview> getSubViews() {
         if (this.subViews == null) {
-            ArrayList<Subview> subViews = data.getParcelableArrayList(SUB_VIEWS);
-            if (subViews == null) {
-                subViews = new ArrayList<>();
-            }
-            this.subViews = subViews;
+            this.subViews = data.getParcelableArrayList(SUB_VIEWS) != null ? data.getParcelableArrayList(SUB_VIEWS) : new ArrayList<>();
         }
         return this.subViews;
     }

--- a/shaky/src/main/java/com/linkedin/android/shaky/Result.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Result.java
@@ -21,6 +21,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Wrapper class for the data collected.
@@ -31,10 +33,14 @@ public class Result {
     private static final String TITLE = PREFIX + ".title";
     private static final String SCREENSHOT_URI = PREFIX + ".screenshotUri";
     private static final String ATTACHMENTS = PREFIX + ".attachments";
+    private static final String SUB_VIEWS = PREFIX + ".subviews";
     private static final String SUBCATEGORY = PREFIX + ".subcategory";
 
     private final Bundle data;
     private ArrayList<Uri> attachments;
+
+    @Nullable
+    private ArrayList<Subview> subViews;
 
     Result(@NonNull Bundle data) {
         this.data = data;
@@ -91,6 +97,22 @@ public class Result {
 
     void setAttachments(ArrayList<Uri> attachments) {
         this.attachments = attachments;
+    }
+
+    @Nullable
+    public ArrayList<Subview> getSubViews() {
+        if (this.subViews == null) {
+            ArrayList<Subview> subViews = data.getParcelableArrayList(SUB_VIEWS);
+            if (subViews == null) {
+                subViews = new ArrayList<>();
+            }
+            this.subViews = subViews;
+        }
+        return this.subViews;
+    }
+
+    void setSubViews(@Nullable ArrayList<Subview> subViews) {
+        this.subViews = subViews;
     }
 
     @Nullable

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -25,6 +25,7 @@ import android.graphics.Bitmap;
 import android.hardware.SensorManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -132,6 +133,26 @@ public class Shaky implements ShakeDetector.Listener {
         } else {
             stop();
         }
+    }
+
+    public void setViewOwner(@Nullable View view, @Nullable String owner) {
+        if (view != null) {
+            view.setTag(R.id.shaky_owner_tag, owner);
+        }
+    }
+
+    @Nullable
+    public String getViewOwner(@Nullable View view) {
+        if(view == null) {
+            return null;
+        }
+
+        Object ownerTag = view.getTag(R.id.shaky_owner_tag);
+        if(ownerTag == null) {
+            return null;
+        }
+
+        return String.valueOf(ownerTag);
     }
 
     private void doStartFeedbackFlow() {
@@ -319,6 +340,7 @@ public class Shaky implements ShakeDetector.Listener {
      */
     private void startFeedbackActivity(@NonNull Result result) {
         Intent intent = FeedbackActivity.newIntent(activity,
+                result.getSubViews(),
                 result.getScreenshotUri(),
                 result.getData(),
                 delegate.resMenu,

--- a/shaky/src/main/java/com/linkedin/android/shaky/Slate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Slate.java
@@ -1,0 +1,110 @@
+package com.linkedin.android.shaky;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.core.graphics.ColorUtils;
+
+import java.util.ArrayList;
+
+/**
+ *  Drawable view on an image to show views in the screen to select
+ */
+public class Slate extends AppCompatImageView {
+    private static final float THIN_STROKE_WIDTH = 12f;
+    private final Paint paint = new Paint();
+    private ArrayList<Subview> allSubViews = new ArrayList<>();
+    private ArrayList<Subview> selectedSubViews = new ArrayList<>();
+    private ArrayList<Subview> subViewsToDraw = new ArrayList<>();
+
+    public Slate(@NonNull Context context, @NonNull AttributeSet attrs) {
+        super(context, attrs);
+
+        paint.setColor(Color.CYAN);
+        paint.setStrokeWidth(THIN_STROKE_WIDTH);
+        paint.setStyle(Paint.Style.STROKE);
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        Parcelable superState = super.onSaveInstanceState();
+        Bundle savedState = new Bundle();
+        savedState.putParcelable("superState", superState);
+        return savedState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        if (state instanceof Bundle) {
+            Bundle savedState = (Bundle) state;
+            Parcelable superState = savedState.getParcelable("superState");
+            super.onRestoreInstanceState(superState);
+        } else {
+            super.onRestoreInstanceState(state);
+        }
+        invalidate();
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        for (Subview subView : subViewsToDraw) {
+            if (subView.isSelected) {
+                paint.setColor(ColorUtils.setAlphaComponent(Color.RED, 50));
+                paint.setStyle(Paint.Style.FILL);
+            } else {
+                paint.setColor(subView.color);
+                paint.setStyle(Paint.Style.STROKE);
+            }
+            canvas.drawRect(subView.rectangle, paint);
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            int x = (int) event.getX();
+            int y = (int) event.getY();
+            for (Subview subView : subViewsToDraw) {
+                if (subView.rectangle.contains(x, y)) {
+                    subView.isSelected = !subView.isSelected;
+                    if(subView.isSelected) {
+                        selectedSubViews.add(subView);
+                    } else {
+                        selectedSubViews.remove(subView);
+                    }
+                    invalidate();
+                    return true;
+                }
+            }
+        }
+        return super.onTouchEvent(event);
+    }
+
+    public void setupSubViews(@NonNull ArrayList<Subview> subViews) {
+        allSubViews = new ArrayList<>();
+        allSubViews.addAll(subViews);
+        subViewsToDraw = allSubViews;
+    }
+
+    public void updateSelectedViews() {
+        subViewsToDraw = selectedSubViews;
+        invalidate();
+    }
+
+    /**
+     * @return the current selection as a Bitmap
+     */
+    public Bitmap capture() {
+        return Utils.capture(this);
+    }
+}

--- a/shaky/src/main/java/com/linkedin/android/shaky/Subview.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Subview.java
@@ -1,0 +1,58 @@
+package com.linkedin.android.shaky;
+
+import android.graphics.Rect;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class Subview implements Parcelable {
+    @NonNull public final Rect rectangle;
+    @Nullable public final String ownerEmail;
+
+    @ColorInt public final int color;
+
+    public boolean isSelected;
+
+
+    public Subview(@NonNull Rect rectangle, @Nullable String ownerEmail, @ColorInt int color, boolean isSelected) {
+        this.rectangle = rectangle;
+        this.color = color;
+        this.isSelected = isSelected;
+        this.ownerEmail = ownerEmail;
+    }
+
+    private Subview(Parcel in) {
+        rectangle = in.readParcelable(Rect.class.getClassLoader());
+        color = in.readInt();
+        isSelected = in.readInt() == 0;
+        ownerEmail = in.readString();
+    }
+
+    public static final Creator<Subview> CREATOR = new Creator<Subview>() {
+        @Override
+        public Subview createFromParcel(Parcel in) {
+            return new Subview(in);
+        }
+
+        @Override
+        public Subview[] newArray(int size) {
+            return new Subview[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeParcelable(rectangle, i);
+        parcel.writeInt(color);
+        parcel.writeInt(isSelected ? 0 : 1);
+        parcel.writeString(ownerEmail);
+    }
+}

--- a/shaky/src/main/res/layout/shaky_select_view.xml
+++ b/shaky/src/main/res/layout/shaky_select_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright (C) 2016 LinkedIn Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/shakyImageEditorBackgroundColor">
+
+    <com.linkedin.android.shaky.Slate
+        android:id="@+id/shaky_slate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+    <Button
+        android:id="@+id/shaky_button_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:text="@string/shaky_select_view_save_and_next"
+        android:theme="?attr/shakyImageEditorButtonTheme" />
+</FrameLayout>

--- a/shaky/src/main/res/values-ar/shaky_strings.xml
+++ b/shaky/src/main/res/values-ar/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">مسح</string>
     <string name="shaky_draw_brush_hint">تحديد نوع المحدد</string>
 
+    <string name="shaky_select_view_save_and_next">حفظ وبعد ذلك</string>
     <string name="shaky_empty_feedback_message">برجاء كتابة تقييمك.</string>
     <string name="shaky_empty_feedback_confirm">موافق</string>
 

--- a/shaky/src/main/res/values-cs/shaky_strings.xml
+++ b/shaky/src/main/res/values-cs/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">Štětec</string>
     <string name="shaky_draw_brush_hint">Přepnout styl tužky</string>
 
+    <string name="shaky_select_view_save_and_next">Uložit a další</string>
     <string name="shaky_empty_feedback_message">Napište prosím své připomínky.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-da/shaky_strings.xml
+++ b/shaky/src/main/res/values-da/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">radér</string>
     <string name="shaky_draw_brush_hint">Vælger penseltype</string>
 
+    <string name="shaky_select_view_save_and_next">Gem og næste</string>
     <string name="shaky_empty_feedback_message">Skriv din feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-de/shaky_strings.xml
+++ b/shaky/src/main/res/values-de/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">Korrektur</string>
     <string name="shaky_draw_brush_hint">Pinselart ändern</string>
 
+    <string name="shaky_select_view_save_and_next">Speichern und weiter</string>
     <string name="shaky_empty_feedback_message">Bitte verfassen Sie Ihr Feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-es/shaky_strings.xml
+++ b/shaky/src/main/res/values-es/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">borrar</string>
     <string name="shaky_draw_brush_hint">Alternar el estilo de pincel</string>
 
+    <string name="shaky_select_view_save_and_next">Guardar y siguiente</string>
     <string name="shaky_empty_feedback_message">Escribe tus comentarios</string>
     <string name="shaky_empty_feedback_confirm">Aceptar</string>
 

--- a/shaky/src/main/res/values-fr/shaky_strings.xml
+++ b/shaky/src/main/res/values-fr/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">typex</string>
     <string name="shaky_draw_brush_hint">passer à un autre style de pinceau</string>
 
+    <string name="shaky_select_view_save_and_next">Enregistrer et suivant</string>
     <string name="shaky_empty_feedback_message">Veuillez rédiger votre feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-in/shaky_strings.xml
+++ b/shaky/src/main/res/values-in/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">whiteout</string>
     <string name="shaky_draw_brush_hint">Ganti gaya brush</string>
 
+    <string name="shaky_select_view_save_and_next">Simpan dan selanjutnya</string>
     <string name="shaky_empty_feedback_message">Harap tulis feedback Anda.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-it/shaky_strings.xml
+++ b/shaky/src/main/res/values-it/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">cancellino</string>
     <string name="shaky_draw_brush_hint">Alterna gli stili del pennello</string>
 
+    <string name="shaky_select_view_save_and_next">Salva e avanti</string>
     <string name="shaky_empty_feedback_message">Scrivi i tuoi commenti.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-ja/shaky_strings.xml
+++ b/shaky/src/main/res/values-ja/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">白で修正</string>
     <string name="shaky_draw_brush_hint">ブラシのスタイルを切り替え</string>
 
+    <string name="shaky_select_view_save_and_next">保存して次へ</string>
     <string name="shaky_empty_feedback_message">フィードバックを記入してください。</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-ko/shaky_strings.xml
+++ b/shaky/src/main/res/values-ko/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">지우기</string>
     <string name="shaky_draw_brush_hint">붓 종류 선택</string>
 
+    <string name="shaky_select_view_save_and_next">저장 후 다음</string>
     <string name="shaky_empty_feedback_message">의견을 쓰세요.</string>
     <string name="shaky_empty_feedback_confirm">확인</string>
 

--- a/shaky/src/main/res/values-ms/shaky_strings.xml
+++ b/shaky/src/main/res/values-ms/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">padam</string>
     <string name="shaky_draw_brush_hint">Tukar tetapan gaya berus</string>
 
+    <string name="shaky_select_view_save_and_next">Simpan dan seterusnya</string>
     <string name="shaky_empty_feedback_message">Sila tuliskan maklum balas anda.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-nb/shaky_strings.xml
+++ b/shaky/src/main/res/values-nb/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">korrigering</string>
     <string name="shaky_draw_brush_hint">Velg penseltype</string>
 
+    <string name="shaky_select_view_save_and_next">Lagre og neste</string>
     <string name="shaky_empty_feedback_message">Skriv tilbakemelding.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-nl/shaky_strings.xml
+++ b/shaky/src/main/res/values-nl/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">vlakgom</string>
     <string name="shaky_draw_brush_hint">Schakelknop voor kwaststijl</string>
 
+    <string name="shaky_select_view_save_and_next">Opslaan en volgende</string>
     <string name="shaky_empty_feedback_message">Schrijf uw feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-pl/shaky_strings.xml
+++ b/shaky/src/main/res/values-pl/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">korektor</string>
     <string name="shaky_draw_brush_hint">Włącz styl pędzla</string>
 
+    <string name="shaky_select_view_save_and_next">Zapisz i dalej</string>
     <string name="shaky_empty_feedback_message">Napisz opinię.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-pt/shaky_strings.xml
+++ b/shaky/src/main/res/values-pt/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">marcar em branco</string>
     <string name="shaky_draw_brush_hint">Altera o tipo de pincel</string>
 
+    <string name="shaky_select_view_save_and_next">Salvar e próximo</string>
     <string name="shaky_empty_feedback_message">Escreva seu feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-ro/shaky_strings.xml
+++ b/shaky/src/main/res/values-ro/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">coloraţi cu alb</string>
     <string name="shaky_draw_brush_hint">Comută stilul pensulei</string>
 
+    <string name="shaky_select_view_save_and_next">Salvați și următorul</string>
     <string name="shaky_empty_feedback_message">Scrieţi feedbackul dvs.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-ru/shaky_strings.xml
+++ b/shaky/src/main/res/values-ru/shaky_strings.xml
@@ -53,6 +53,7 @@
     <string name="shaky_draw_brush_white">закрасить</string>
     <string name="shaky_draw_brush_hint">Переключатель стиля обозначения</string>
 
+    <string name="shaky_select_view_save_and_next">Сохранить и далее</string>
     <string name="shaky_empty_feedback_message">Напишите свой отзыв</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-sv/shaky_strings.xml
+++ b/shaky/src/main/res/values-sv/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">korrigering</string>
     <string name="shaky_draw_brush_hint">Välj mellan penslar</string>
 
+    <string name="shaky_select_view_save_and_next">Spara och nästa</string>
     <string name="shaky_empty_feedback_message">Skriv din feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-th/shaky_strings.xml
+++ b/shaky/src/main/res/values-th/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">ทาสีขาวทับ</string>
     <string name="shaky_draw_brush_hint">สลับสไตล์การปัด</string>
 
+    <string name="shaky_select_view_save_and_next">บันทึกและถัดไป</string>
     <string name="shaky_empty_feedback_message">โปรดเขียนคำติชมของคุณ</string>
     <string name="shaky_empty_feedback_confirm">ตกลง</string>
 

--- a/shaky/src/main/res/values-tl/shaky_strings.xml
+++ b/shaky/src/main/res/values-tl/shaky_strings.xml
@@ -55,6 +55,7 @@
     <string name="shaky_draw_brush_white">whiteout</string>
     <string name="shaky_draw_brush_hint">I-toggle ang estilong brush</string>
 
+    <string name="shaky_select_view_save_and_next">I-save at susunod</string>
     <string name="shaky_empty_feedback_message">Pakisulat ang iyong feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 

--- a/shaky/src/main/res/values-tr/shaky_strings.xml
+++ b/shaky/src/main/res/values-tr/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">daksille</string>
     <string name="shaky_draw_brush_hint">Fırça sitilini değiştir</string>
 
+    <string name="shaky_select_view_save_and_next">Kaydet ve sonraki</string>
     <string name="shaky_empty_feedback_message">Lütfen geri bildiriminizi yazın.</string>
     <string name="shaky_empty_feedback_confirm">Tamam</string>
 

--- a/shaky/src/main/res/values-zh-rCN/shaky_strings.xml
+++ b/shaky/src/main/res/values-zh-rCN/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">涂白</string>
     <string name="shaky_draw_brush_hint">切换画笔类型</string>
 
+    <string name="shaky_select_view_save_and_next">保存並下一步</string>
     <string name="shaky_empty_feedback_message">欢迎提出您的宝贵意见！</string>
     <string name="shaky_empty_feedback_confirm">确定</string>
 

--- a/shaky/src/main/res/values-zh-rTW/shaky_strings.xml
+++ b/shaky/src/main/res/values-zh-rTW/shaky_strings.xml
@@ -54,6 +54,7 @@
     <string name="shaky_draw_brush_white">橡皮擦</string>
     <string name="shaky_draw_brush_hint">切換筆刷樣式</string>
 
+    <string name="shaky_select_view_save_and_next">保存并下一步</string>
     <string name="shaky_empty_feedback_message">請輸入意見反映。</string>
     <string name="shaky_empty_feedback_confirm">確認</string>
 

--- a/shaky/src/main/res/values/ids.xml
+++ b/shaky/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="shaky_owner_tag" type="id" />
+</resources>

--- a/shaky/src/main/res/values/shaky_strings.xml
+++ b/shaky/src/main/res/values/shaky_strings.xml
@@ -53,6 +53,8 @@
     <string name="shaky_draw_brush_white">whiteout</string>
     <string name="shaky_draw_brush_hint">Toggles the brush style</string>
 
+    <string name="shaky_select_view_save_and_next">save and next</string>
+
     <string name="shaky_empty_feedback_message">Please write your feedback.</string>
     <string name="shaky_empty_feedback_confirm">OK</string>
 


### PR DESCRIPTION
* **Motivation:** 
We currently do not have a way to specify owner of a view in a screen. We have the option of user selecting a view using the brush, but we still need to manually triage tickets if there are multiple owners in a screen. This code change will add support for specifying owner at a view level instead of a screen level.
* **Impact:** 
This will help with triaging tickets/emails manually that are created when using shaky.
* **Design:** 
We added a new screen for users to select the view that is not as expected. We show this selection screen when there is atleast one view which has owner that is not the screen's owner.
* **Risk:** 
Low, as majority of code is in the new screen which will not be shown if we do not define the owner of the view.
![Screenshot_20230320_151054](https://user-images.githubusercontent.com/10890093/226476779-53dda7d8-39d3-4ac9-9a12-99797a0e5a2d.png)


