### PR TITLE
Fix shaky crash due to : Software rendering doesn't support hardware bitmaps

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/Paper.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Paper.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.android.shaky;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -27,8 +28,10 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatImageView;
 import android.util.AttributeSet;
+import android.view.ContextThemeWrapper;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.Window;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -158,7 +161,16 @@ public class Paper extends AppCompatImageView {
      * @return the current drawing as a Bitmap
      */
     public Bitmap capture() {
-        return Utils.capture(this);
+        Window window = null;
+        if (getContext() instanceof Activity) {
+            window = ((Activity)(getContext())).getWindow();
+        } else if (getContext() instanceof ContextThemeWrapper) {
+            Context baseContext = ((ContextThemeWrapper)getContext()).getBaseContext();
+            if (baseContext instanceof Activity) {
+                window = ((Activity)baseContext).getWindow();
+            }
+        }
+        return Utils.capture(this, window);
     }
 
     private void applyEvents() {

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -238,7 +238,7 @@ public class Shaky implements ShakeDetector.Listener {
             // Fallback to using the default screenshot capture mechanism if Falcon does not work (e.g. if it has not
             // been updated to work on newer versions of Android yet)
             View view = activity.getWindow().getDecorView().getRootView();
-            return Utils.capture(view);
+            return Utils.capture(view, activity.getWindow());
         }
     }
 

--- a/shaky/src/main/java/com/linkedin/android/shaky/Utils.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Utils.java
@@ -19,16 +19,23 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Rect;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.annotation.WorkerThread;
 import androidx.core.content.FileProvider;
+
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
+import android.view.PixelCopy;
 import android.view.View;
+import android.view.Window;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -103,15 +110,26 @@ final class Utils {
      * Saves the view as a Bitmap screenshot.
      */
     @Nullable
-    static Bitmap capture(View view) {
-        if (view.getWidth() == 0 || view.getHeight() == 0) {
-            return null;
-        }
+    static Bitmap capture(View view, Window window) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888);
+            int[] location = new int[2];
+            view.getLocationInWindow(location);
+            PixelCopy.request(window,
+                    new Rect(location[0], location[1], location[0] + view.getWidth(), location[1] +view.getHeight()),
+                    bitmap, copyResult -> {},
+                    new Handler(Looper.getMainLooper()));
+            return bitmap;
+        } else {
+            if (view.getWidth() == 0 || view.getHeight() == 0) {
+                return null;
+            }
 
-        Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.RGB_565);
-        Canvas canvas = new Canvas(bitmap);
-        view.draw(canvas);
-        return bitmap;
+            Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.RGB_565);
+            Canvas canvas = new Canvas(bitmap);
+            view.draw(canvas);
+            return bitmap;
+        }
     }
 
     /**


### PR DESCRIPTION
Using PixelCopy API in Android O and beyond to prevent the IllegalArgument crash caused by hardware bitmaps.