### PR TITLE
Add support for Android 15

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
       - name: Checkout Repo
         uses: actions/checkout@v2
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -16,7 +15,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     group = GROUP_ID

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.7.2'
     }
 }
 
@@ -24,8 +24,8 @@ subprojects {
 }
 
 ext {
-    compileSdkVersion = 31
-    buildToolsVersion = '31.0.0'
+    compileSdkVersion = 35
+    buildToolsVersion = '35.0.0'
     minSdkVersion = 21
-    targetSdkVersion = 30
+    targetSdkVersion = 35
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -8,23 +8,6 @@ tasks.register("sourcesJar", Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-//tasks.register('androidJavadocs', Javadoc) {
-//    failOnError false
-//    source = android.sourceSets.main.java.srcDirs
-//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-//    android.libraryVariants.all { variant ->
-//        if (variant.name == 'release') {
-//            owner.classpath += variant.javaCompileProvider.get().classpath
-//        }
-//    }
-//    exclude '**/R.html', '**/R.*.html', '**/index.html'
-//}
-//
-//tasks.register('androidJavadocsJar', Jar) {
-//    dependsOn androidJavadocs
-//    from androidJavadocs.destinationDir
-//}
-
 // AGP creates the components in afterEvaluate, so we need to use it too
 // https://developer.android.com/studio/build/maven-publish-plugin
 afterEvaluate {

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -15,7 +15,6 @@ afterEvaluate {
         publications {
             maven(MavenPublication){
                 from(components["release"])
-                // Adds javadocs and sources as separate jars.
                 artifact sourcesJar
                 pom {
                     name = 'Shaky'

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -4,20 +4,26 @@ apply plugin: 'signing'
 // Ideally AGP should provide sources and javadoc integration for their components:
 // https://issuetracker.google.com/issues/145670440
 tasks.register("sourcesJar", Jar) {
-    classifier 'sources'
+    archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
 }
 
-tasks.register("javadoc", Javadoc) {
+tasks.register('androidJavadocs', Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    android.libraryVariants.all { variant ->
+        if (variant.name == 'release') {
+            owner.classpath += variant.javaCompileProvider.get().classpath
+        }
+    }
+    exclude '**/R.html', '**/R.*.html', '**/index.html'
 }
 
-tasks.register("javadocJar", Jar) {
-    dependsOn javadoc
-    classifier 'javadoc'
-    from javadoc.destinationDir
+tasks.register('androidJavadocsJar', Jar) {
+    dependsOn androidJavadocs
+    archiveClassifier.set('javadoc')
+    from androidJavadocs.destinationDir
 }
 
 // AGP creates the components in afterEvaluate, so we need to use it too
@@ -25,12 +31,11 @@ tasks.register("javadocJar", Jar) {
 afterEvaluate {
     publishing {
         publications {
-            maven(MavenPublication) {
-                from components.release
-
+            maven(MavenPublication){
+                from(components["release"])
+                // Adds javadocs and sources as separate jars.
                 artifact sourcesJar
-                artifact javadocJar
-
+                artifact androidJavadocsJar
                 pom {
                     name = 'Shaky'
                     description = 'Shake-to-send-feedback library for Android'

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -8,6 +8,18 @@ tasks.register("sourcesJar", Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
+tasks.register("androidJavadoc", Javadoc) {
+    failOnError false
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+tasks.register("androidJavadocJar", Jar) {
+    dependsOn androidJavadoc
+    archiveClassifier.set('javadoc')
+    from androidJavadoc.destinationDir
+}
+
 // AGP creates the components in afterEvaluate, so we need to use it too
 // https://developer.android.com/studio/build/maven-publish-plugin
 afterEvaluate {
@@ -16,6 +28,7 @@ afterEvaluate {
             maven(MavenPublication){
                 from(components["release"])
                 artifact sourcesJar
+                artifact androidJavadocJar
                 pom {
                     name = 'Shaky'
                     description = 'Shake-to-send-feedback library for Android'

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -8,23 +8,22 @@ tasks.register("sourcesJar", Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-tasks.register('androidJavadocs', Javadoc) {
-    failOnError false
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    android.libraryVariants.all { variant ->
-        if (variant.name == 'release') {
-            owner.classpath += variant.javaCompileProvider.get().classpath
-        }
-    }
-    exclude '**/R.html', '**/R.*.html', '**/index.html'
-}
-
-tasks.register('androidJavadocsJar', Jar) {
-    dependsOn androidJavadocs
-    archiveClassifier.set('javadoc')
-    from androidJavadocs.destinationDir
-}
+//tasks.register('androidJavadocs', Javadoc) {
+//    failOnError false
+//    source = android.sourceSets.main.java.srcDirs
+//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+//    android.libraryVariants.all { variant ->
+//        if (variant.name == 'release') {
+//            owner.classpath += variant.javaCompileProvider.get().classpath
+//        }
+//    }
+//    exclude '**/R.html', '**/R.*.html', '**/index.html'
+//}
+//
+//tasks.register('androidJavadocsJar', Jar) {
+//    dependsOn androidJavadocs
+//    from androidJavadocs.destinationDir
+//}
 
 // AGP creates the components in afterEvaluate, so we need to use it too
 // https://developer.android.com/studio/build/maven-publish-plugin
@@ -35,7 +34,6 @@ afterEvaluate {
                 from(components["release"])
                 // Adds javadocs and sources as separate jars.
                 artifact sourcesJar
-                artifact androidJavadocsJar
                 pom {
                     name = 'Shaky'
                     description = 'Shake-to-send-feedback library for Android'

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -8,16 +8,16 @@ tasks.register("sourcesJar", Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-tasks.register("androidJavadoc", Javadoc) {
+tasks.register("javadoc", Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 }
 
-tasks.register("androidJavadocJar", Jar) {
-    dependsOn androidJavadoc
+tasks.register("javadocJar", Jar) {
+    dependsOn javadoc
     archiveClassifier.set('javadoc')
-    from androidJavadoc.destinationDir
+    from javadoc.destinationDir
 }
 
 // AGP creates the components in afterEvaluate, so we need to use it too
@@ -28,7 +28,7 @@ afterEvaluate {
             maven(MavenPublication){
                 from(components["release"])
                 artifact sourcesJar
-                artifact androidJavadocJar
+                artifact javadocJar
                 pom {
                     name = 'Shaky'
                     description = 'Shake-to-send-feedback library for Android'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/shaky-sample/build.gradle
+++ b/shaky-sample/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace "com.linkedin.android.shaky.app"
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {

--- a/shaky-sample/src/main/AndroidManifest.xml
+++ b/shaky-sample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.linkedin.android.shaky.app"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
     <!-- for MultipleAttachmentShakeDelegate example -->
     <uses-permission android:name="android.permission.READ_LOGS"
@@ -16,7 +15,8 @@
 
         <activity
             android:name=".ShakyDemo"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/shaky-sample/src/main/res/values/styles.xml
+++ b/shaky-sample/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
@@ -43,6 +43,10 @@
         <item name="shakyPopupButtonColor">@color/light_red</item>
         <item name="shakyPopupTitleColor">@android:color/white</item>
         <item name="shakyPopupContentColor">@android:color/white</item>
+    </style>
+
+    <style name="OptOutEdgeToEdgeEnforcement">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
 </resources>

--- a/shaky-sample/src/main/res/values/styles.xml
+++ b/shaky-sample/src/main/res/values/styles.xml
@@ -44,9 +44,4 @@
         <item name="shakyPopupTitleColor">@android:color/white</item>
         <item name="shakyPopupContentColor">@android:color/white</item>
     </style>
-
-    <style name="OptOutEdgeToEdgeEnforcement">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
-    </style>
-
 </resources>

--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -19,8 +19,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
-            proguardFiles 'proguard.cfg'
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 
@@ -33,12 +33,6 @@ android {
     }
 
     resourcePrefix 'shaky_'
-}
-
-tasks.configureEach {
-    if (it.name == 'testReleaseUnitTest') {
-        it.enabled = false
-    }
 }
 
 dependencies {

--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -17,9 +17,15 @@ android {
         versionName "1.0"
     }
 
-    publishing {
-        singleVariant("release") {
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles 'proguard.cfg'
         }
+    }
+
+    publishing {
+       singleVariant("release")
     }
 
     lintOptions {
@@ -32,13 +38,14 @@ android {
 dependencies {
     api 'com.squareup:seismic:1.0.3'
     implementation 'com.jraska:falcon:2.2.0'
-    implementation "androidx.appcompat:appcompat:1.3.1"
-    implementation "com.google.android.material:material:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.appcompat:appcompat:1.7.0"
+    implementation "com.google.android.material:material:1.12.0"
+    implementation "androidx.recyclerview:recyclerview:1.3.2"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation "androidx.annotation:annotation:1.6.0"
+    implementation "androidx.annotation:annotation:1.9.1"
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.12.4'
-    testImplementation 'org.robolectric:robolectric:4.14-beta-1'
+    testImplementation 'org.mockito:mockito-core:5.14.2'
+    testImplementation 'org.robolectric:robolectric:4.13'
 }
+

--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -3,7 +3,7 @@ apply from: "$rootDir/gradle/publishing.gradle"
 
 android {
     namespace "com.linkedin.android.shaky"
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -35,6 +35,12 @@ android {
     resourcePrefix 'shaky_'
 }
 
+tasks.configureEach {
+    if (it.name == 'testReleaseUnitTest') {
+        it.enabled = false
+    }
+}
+
 dependencies {
     api 'com.squareup:seismic:1.0.3'
     implementation 'com.jraska:falcon:2.2.0'
@@ -48,4 +54,3 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.14.2'
     testImplementation 'org.robolectric:robolectric:4.13'
 }
-

--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply from: "$rootDir/gradle/publishing.gradle"
 
 android {
+    namespace "com.linkedin.android.shaky"
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
@@ -16,10 +17,11 @@ android {
         versionName "1.0"
     }
 
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+    publishing {
+        singleVariant("release") {
+            // if you don't want sources/javadoc, remove these lines
+            withSourcesJar()
+            withJavadocJar()
         }
     }
 
@@ -41,5 +43,5 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.12.4'
-    testImplementation 'org.robolectric:robolectric:4.9.2'
+    testImplementation 'org.robolectric:robolectric:4.14-beta-1'
 }

--- a/shaky/build.gradle
+++ b/shaky/build.gradle
@@ -19,9 +19,6 @@ android {
 
     publishing {
         singleVariant("release") {
-            // if you don't want sources/javadoc, remove these lines
-            withSourcesJar()
-            withJavadocJar()
         }
     }
 

--- a/shaky/src/main/AndroidManifest.xml
+++ b/shaky/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<manifest package="com.linkedin.android.shaky"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application android:supportsRtl="true">
         <activity android:name="com.linkedin.android.shaky.FeedbackActivity" />

--- a/shaky/src/main/res/values/shaky_styles.xml
+++ b/shaky/src/main/res/values/shaky_styles.xml
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="ShakyBaseAlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:colorBackground">?attr/shakyBackgroundColor</item>
@@ -70,6 +70,9 @@
         <item name="shakyAlertDialogTheme">@style/ShakyBaseAlertDialogTheme</item>
         <item name="alertDialogTheme">?attr/shakyAlertDialogTheme</item>
         <item name="materialAlertDialogTheme">?attr/shakyAlertDialogTheme</item>
+
+        <!-- Opt out of Edge to Edge enforcement required from Android 15 -->
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
     <style name="ShakyBasePopupTheme" parent="Theme.AppCompat.Light.Dialog.Alert">


### PR DESCRIPTION
This PR is intended for following:
1. Bump to latest AGP and Gradle versions
2. Add support for Android 15 on Shaky. 
3. Enable opt out of edge to edge validation until we have finalized next steps.

Generated snapshot locally:
<img width="949" alt="Screenshot 2024-11-12 at 12 45 32 PM" src="https://github.com/user-attachments/assets/bc556899-5862-44d0-82de-b062dde4f96b">


Testing with the fix 
![Screenshot 2024-11-12 at 12 31 45 PM](https://github.com/user-attachments/assets/6747b658-00d6-48a6-871e-b7d1a6856d94)

