### PR TITLE
Add support to perform custom action in feedback dialog

### DIFF
--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -22,7 +22,7 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.Toast;
 
-import com.linkedin.android.shaky.SendFeedbackDialog;
+import com.linkedin.android.shaky.ActionConstants;
 
 import java.util.Random;
 
@@ -76,7 +76,7 @@ public class ShakyDemo extends Activity {
             @Override
             public void onClick(View v) {
                 ((ShakyApplication) getApplication()).getShaky()
-                        .startFeedbackFlow(SendFeedbackDialog.ACTION_START_BUG_REPORT);
+                        .startFeedbackFlow(ActionConstants.ACTION_START_BUG_REPORT);
             }
         });
     }

--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -16,12 +16,13 @@
 package com.linkedin.android.shaky.app;
 
 import android.app.Activity;
-import android.app.Application;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.Toast;
+
+import com.linkedin.android.shaky.SendFeedbackDialog;
 
 import java.util.Random;
 
@@ -67,7 +68,15 @@ public class ShakyDemo extends Activity {
         findViewById(R.id.demo_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ((ShakyApplication) getApplication()).getShaky().startFeedbackFlow();
+                ((ShakyApplication) getApplication()).getShaky().startFeedbackFlow(null);
+            }
+        });
+
+        findViewById(R.id.demo_bug_report_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ((ShakyApplication) getApplication()).getShaky()
+                        .startFeedbackFlow(SendFeedbackDialog.ACTION_START_BUG_REPORT);
             }
         });
     }

--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -68,7 +68,7 @@ public class ShakyDemo extends Activity {
         findViewById(R.id.demo_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ((ShakyApplication) getApplication()).getShaky().startFeedbackFlow(null);
+                ((ShakyApplication) getApplication()).getShaky().startFeedbackFlow();
             }
         });
 

--- a/shaky-sample/src/main/res/layout/activity_demo.xml
+++ b/shaky-sample/src/main/res/layout/activity_demo.xml
@@ -43,4 +43,11 @@
         android:layout_height="wrap_content"
         android:text="@string/manual_feedback_trigger"/>
 
+    <Button
+        android:id="@+id/demo_bug_report_button"
+        style="?attr/borderlessButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/manual_bug_report"/>
+
 </LinearLayout>

--- a/shaky-sample/src/main/res/values/strings.xml
+++ b/shaky-sample/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name" translatable="false">Shaky</string>
     <string name="shake_me" translatable="false">Shake me!</string>
     <string name="manual_feedback_trigger" translatable="false">Manually start feedback</string>
+    <string name="manual_bug_report" translatable="false">Manually start bug report</string>
     <string name="show_toast" translatable="false">Show Toast</string>
     <string name="toast_text" translatable="false">This is a toast.</string>
     <string name="christmas_theme" translatable="false">Use Christmas theme</string>

--- a/shaky/src/main/java/com/linkedin/android/shaky/ActionConstants.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ActionConstants.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.android.shaky;
+
+/**
+ * Class to hold actions that can be performed on shaky.
+ */
+public class ActionConstants {
+
+    public static final String ACTION_START_FEEDBACK_FLOW = "StartFeedbackFlow";
+    public static final String ACTION_START_BUG_REPORT = "StartBugReport";
+    public static final String ACTION_DIALOG_DISMISSED_BY_USER = "DialogDismissedByUser";
+}

--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -46,6 +46,7 @@ public class FeedbackActivity extends AppCompatActivity {
     static final String RES_MENU = "resMenu";
     static final String SUBCATEGORY = "subcategory";
     static final String THEME = "theme";
+    private static final String ACTION = "ACTION_THAT_STARTED_THE_ACTIVITY";
     static final int MISSING_RESOURCE = 0;
 
     private Uri imageUri;
@@ -59,11 +60,13 @@ public class FeedbackActivity extends AppCompatActivity {
                                    @Nullable Uri screenshotUri,
                                    @Nullable Bundle userData,
                                    @MenuRes int resMenu,
+                                   @Nullable String actionThatStartedTheActivity,
                                    @StyleRes int theme) {
         Intent intent = new Intent(context, FeedbackActivity.class);
         intent.putExtra(SCREENSHOT_URI, screenshotUri);
         intent.putExtra(USER_DATA, userData);
         intent.putExtra(RES_MENU, resMenu);
+        intent.putExtra(ACTION, actionThatStartedTheActivity);
         intent.putExtra(THEME, theme);
         return intent;
     }
@@ -80,12 +83,20 @@ public class FeedbackActivity extends AppCompatActivity {
         imageUri = getIntent().getParcelableExtra(SCREENSHOT_URI);
         userData = getIntent().getBundleExtra(USER_DATA);
         resMenu = getIntent().getIntExtra(RES_MENU, FormFragment.DEFAULT_MENU);
+        String action = getIntent().getStringExtra(ACTION);
 
-        if (savedInstanceState == null) {
-            getSupportFragmentManager()
+        if (savedInstanceState == null && action != null) {
+            if (action.equals(SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW)) {
+                getSupportFragmentManager()
                     .beginTransaction()
                     .add(R.id.shaky_fragment_container, SelectFragment.newInstance(customTheme))
                     .commit();
+            } else if (action.equals(SendFeedbackDialog.ACTION_START_BUG_REPORT)) {
+                startFormFragment(FeedbackItem.BUG, false);
+                if (imageUri != null) {
+                    startDrawFragment();
+                }
+            }
         }
     }
 
@@ -120,19 +131,31 @@ public class FeedbackActivity extends AppCompatActivity {
      * Attaches this intent's extras to the fragment and transitions to the next fragment.
      *
      * @param fragment Fragment the fragment to swap to
+     * @param shouldAddToBackStack if the fragment should be added to backstack or not
      */
-    private void changeToFragment(@NonNull Fragment fragment) {
-        getSupportFragmentManager().beginTransaction()
+    private void changeToFragment(@NonNull Fragment fragment, boolean shouldAddToBackStack) {
+        FragmentTransaction fragmentTransaction = getSupportFragmentManager()
+            .beginTransaction()
             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-            .replace(R.id.shaky_fragment_container, fragment)
-            .addToBackStack(null)
-            .commit();
+            .replace(R.id.shaky_fragment_container, fragment);
+
+        if (shouldAddToBackStack) {
+            fragmentTransaction.addToBackStack(null);
+        }
+
+        fragmentTransaction.commit();
     }
 
     /**
      * Swap the view container for a form fragment, restores the previous fragment if one exists.
+     *
+     * @param feedbackType the FeedbackType for which to start the fragment
+     * @param shouldAddToBackStack if the fragment should be added to backstack or not
      */
-    private void startFormFragment(@FeedbackItem.FeedbackType int feedbackType) {
+    private void startFormFragment(
+        @FeedbackItem.FeedbackType int feedbackType,
+        boolean shouldAddToBackStack
+    ) {
         String title = getString(getTitleResId(feedbackType));
         String hint = getString(getHintResId(feedbackType));
         String[] subtypes = null;
@@ -140,18 +163,19 @@ public class FeedbackActivity extends AppCompatActivity {
             subtypes = new String[]{Subcategories.Bug.CRASH, Subcategories.Bug.NON_FATAL};
         }
         changeToFragment(new FormFragment.Builder(title, hint)
-                .setScreenshotUri(imageUri)
-                .setMenu(resMenu)
-                .setSubtypes(subtypes != null ? R.array.shaky_bug_subcategories : null, subtypes)
-                .setTheme(customTheme)
-                .build());
+            .setScreenshotUri(imageUri)
+            .setMenu(resMenu)
+            .setSubtypes(subtypes != null ? R.array.shaky_bug_subcategories : null, subtypes)
+            .setTheme(customTheme)
+            .build(),
+            shouldAddToBackStack);
     }
 
     /**
      * Swap the view container for a draw fragment, restores the previous fragment if one exists.
      */
     private void startDrawFragment() {
-        changeToFragment(DrawFragment.newInstance(imageUri, customTheme));
+        changeToFragment(DrawFragment.newInstance(imageUri, customTheme), true);
     }
 
     private void setFeedbackType(@FeedbackItem.FeedbackType int feedbackType) {
@@ -167,7 +191,7 @@ public class FeedbackActivity extends AppCompatActivity {
 
                 setFeedbackType(feedbackType);
 
-                startFormFragment(feedbackType);
+                startFormFragment(feedbackType, true);
                 if (imageUri != null && feedbackType == FeedbackItem.BUG) {
                     startDrawFragment();
                 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -86,12 +86,12 @@ public class FeedbackActivity extends AppCompatActivity {
         String action = getIntent().getStringExtra(ACTION);
 
         if (savedInstanceState == null && action != null) {
-            if (action.equals(SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW)) {
+            if (action.equals(ActionConstants.ACTION_START_FEEDBACK_FLOW)) {
                 getSupportFragmentManager()
                     .beginTransaction()
                     .add(R.id.shaky_fragment_container, SelectFragment.newInstance(customTheme))
                     .commit();
-            } else if (action.equals(SendFeedbackDialog.ACTION_START_BUG_REPORT)) {
+            } else if (action.equals(ActionConstants.ACTION_START_BUG_REPORT)) {
                 startFormFragment(FeedbackItem.BUG, false);
                 if (imageUri != null) {
                     startDrawFragment();

--- a/shaky/src/main/java/com/linkedin/android/shaky/SendFeedbackDialog.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/SendFeedbackDialog.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 public class SendFeedbackDialog extends DialogFragment {
 
     public static final String ACTION_START_FEEDBACK_FLOW = "StartFeedbackFlow";
+    public static final String ACTION_START_BUG_REPORT = "StartBugReport";
     public static final String ACTION_DIALOG_DISMISSED_BY_USER = "DialogDismissedByUser";
     public static final String SHOULD_DISPLAY_SETTING_UI = "ShouldDisplaySettingUI";
     public static final String CUSTOM_TITLE = "CustomTitle";
@@ -89,7 +90,7 @@ public class SendFeedbackDialog extends DialogFragment {
         builder.setPositiveButton(R.string.shaky_dialog_positive, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                Intent intent = new Intent(ACTION_START_FEEDBACK_FLOW);
+                Intent intent = new Intent(getActionToPerformOnPositiveClick());
                 LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
             }
         });
@@ -141,5 +142,13 @@ public class SendFeedbackDialog extends DialogFragment {
         if (handler != null) {
             handler.removeCallbacks(runnable);
         }
+    }
+
+    /**
+     * Consumer can override this method to perform a custom action on dialog positive button click,
+     * by default it starts the feedback flow.
+     */
+    public String getActionToPerformOnPositiveClick() {
+        return ACTION_START_FEEDBACK_FLOW;
     }
 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/SendFeedbackDialog.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/SendFeedbackDialog.java
@@ -40,9 +40,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class SendFeedbackDialog extends DialogFragment {
 
-    public static final String ACTION_START_FEEDBACK_FLOW = "StartFeedbackFlow";
-    public static final String ACTION_START_BUG_REPORT = "StartBugReport";
-    public static final String ACTION_DIALOG_DISMISSED_BY_USER = "DialogDismissedByUser";
     public static final String SHOULD_DISPLAY_SETTING_UI = "ShouldDisplaySettingUI";
     public static final String CUSTOM_TITLE = "CustomTitle";
     public static final String CUSTOM_MESSAGE = "CustomMessage";
@@ -97,7 +94,7 @@ public class SendFeedbackDialog extends DialogFragment {
         builder.setNegativeButton(R.string.shaky_dialog_negative, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                Intent intent = new Intent(ACTION_DIALOG_DISMISSED_BY_USER);
+                Intent intent = new Intent(ActionConstants.ACTION_DIALOG_DISMISSED_BY_USER);
                 LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
             }
         });
@@ -149,6 +146,6 @@ public class SendFeedbackDialog extends DialogFragment {
      * by default it starts the feedback flow.
      */
     public String getActionToPerformOnPositiveClick() {
-        return ACTION_START_FEEDBACK_FLOW;
+        return ActionConstants.ACTION_START_FEEDBACK_FLOW;
     }
 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -75,9 +75,9 @@ public class Shaky implements ShakeDetector.Listener {
         shakeDetector.setSensitivity(getDetectorSensitivityLevel());
 
         IntentFilter filter = new IntentFilter();
-        filter.addAction(SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW);
-        filter.addAction(SendFeedbackDialog.ACTION_START_BUG_REPORT);
-        filter.addAction(SendFeedbackDialog.ACTION_DIALOG_DISMISSED_BY_USER);
+        filter.addAction(ActionConstants.ACTION_START_FEEDBACK_FLOW);
+        filter.addAction(ActionConstants.ACTION_START_BUG_REPORT);
+        filter.addAction(ActionConstants.ACTION_DIALOG_DISMISSED_BY_USER);
         filter.addAction(FeedbackActivity.ACTION_END_FEEDBACK_FLOW);
         filter.addAction(FeedbackActivity.ACTION_ACTIVITY_CLOSED_BY_USER);
         filter.addAction(ShakySettingDialog.UPDATE_SHAKY_SENSITIVITY);
@@ -134,7 +134,7 @@ public class Shaky implements ShakeDetector.Listener {
                 actionThatStartedTheActivity = action;
             }
         } else {
-            actionThatStartedTheActivity = SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW;
+            actionThatStartedTheActivity = ActionConstants.ACTION_START_FEEDBACK_FLOW;
         }
         doStartFeedbackFlow();
     }
@@ -192,8 +192,8 @@ public class Shaky implements ShakeDetector.Listener {
      * @return true if the flow is a valid flow.
      */
     private boolean isValidStartAction(String action) {
-        return action.equals(SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW)
-                || action.equals(SendFeedbackDialog.ACTION_START_BUG_REPORT);
+        return action.equals(ActionConstants.ACTION_START_FEEDBACK_FLOW)
+                || action.equals(ActionConstants.ACTION_START_BUG_REPORT);
     }
 
     @Override
@@ -305,13 +305,13 @@ public class Shaky implements ShakeDetector.Listener {
         return new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
-                if (SendFeedbackDialog.ACTION_START_FEEDBACK_FLOW.equals(intent.getAction())
-                        || SendFeedbackDialog.ACTION_START_BUG_REPORT.equals(intent.getAction())) {
+                if (ActionConstants.ACTION_START_FEEDBACK_FLOW.equals(intent.getAction())
+                        || ActionConstants.ACTION_START_BUG_REPORT.equals(intent.getAction())) {
                     if (activity != null) {
                         actionThatStartedTheActivity = intent.getAction();
                         doStartFeedbackFlow();
                     }
-                } else if (SendFeedbackDialog.ACTION_DIALOG_DISMISSED_BY_USER.equals(intent.getAction())
+                } else if (ActionConstants.ACTION_DIALOG_DISMISSED_BY_USER.equals(intent.getAction())
                         || FeedbackActivity.ACTION_ACTIVITY_CLOSED_BY_USER.equals(intent.getAction())) {
                     if (shakyFlowCallback != null) {
                         shakyFlowCallback.onShakyFinished(ShakyFlowCallback.SHAKY_FINISHED_BY_USER);

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -110,7 +110,14 @@ public class Shaky implements ShakeDetector.Listener {
     }
 
     /**
-     * Start shaky manually.
+     * Start the shaky feedback flow manually.
+     */
+    public void startFeedbackFlow() {
+        startFeedbackFlow(null);
+    }
+
+    /**
+     * Start shaky manually for a custom flow.
      *
      * @param action the flow to start. If null, starts the feedback flow by default. Otherwise
      *               starts the custom flow (if valid).


### PR DESCRIPTION
## Summary

- Added support in `SendFeedbackDialog` to start custom flow on positive
  button click of the dialog.
- Added action `ACTION_START_BUG_REPORT` to start the "Report a Bug" flow
  directly.
- Added support in `Shaky` class to start the provided flow.
- Updated `FeedbackActivity` to directly launch the Bug Report screen
  when required.
- Added "Manually start bug report" button in sample app to test the
  `ACTION_START_BUG_REPORT` action manually in shaky.

## Testing Done
Tested locally. Please refer the screen-recordings below:
| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/00f6695c-1cab-435c-a727-b2090f8d9088"> | <video src="https://github.com/user-attachments/assets/08298ca5-16ae-4230-8ab9-a98cfc76235a"> |

