### PR TITLE
Add support for Android 16 edge-to-edge

### DIFF
--- a/shaky-sample/build.gradle
+++ b/shaky-sample/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     implementation project(':shaky')
     implementation "androidx.annotation:annotation:1.0.0"
     implementation "androidx.core:core:1.6.0"
+    implementation "androidx.activity:activity:1.10.1"
 }

--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -22,6 +22,10 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.Toast;
 
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
 import com.linkedin.android.shaky.ActionConstants;
 
 import java.util.Random;
@@ -34,9 +38,15 @@ public class ShakyDemo extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_demo);
-
+        ViewCompat.setOnApplyWindowInsetsListener(
+            getWindow().findViewById(R.id.demo_background),
+            (v, insets) -> {
+                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+                return WindowInsetsCompat.CONSUMED;
+            }
+        );
         View tv = findViewById(R.id.demo_background);
-
         Random random = new Random();
         int color = Color.rgb(random.nextInt(RGB_MAX), random.nextInt(RGB_MAX), random.nextInt(RGB_MAX));
         tv.setBackgroundColor(color);

--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -41,7 +41,8 @@ public class ShakyDemo extends Activity {
         ViewCompat.setOnApplyWindowInsetsListener(
             getWindow().findViewById(R.id.demo_background),
             (v, insets) -> {
-                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                Insets systemBars =
+                    insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
                 v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
                 return WindowInsetsCompat.CONSUMED;
             }

--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -21,15 +21,20 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.activity.EdgeToEdge;
+import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.annotation.MenuRes;
 
 /**
  * The main activity used capture and send feedback.
@@ -74,9 +79,16 @@ public class FeedbackActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         setTheme(R.style.ShakyBaseTheme);
-
+        EdgeToEdge.enable(this);
+        ViewCompat.setOnApplyWindowInsetsListener(
+            getWindow().findViewById(android.R.id.content),
+            (v, insets) -> {
+                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+                return WindowInsetsCompat.CONSUMED;
+            }
+        );
         setContentView(R.layout.shaky_feedback);
 
         customTheme = getIntent().getIntExtra(THEME, MISSING_RESOURCE);

--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -84,7 +84,8 @@ public class FeedbackActivity extends AppCompatActivity {
         ViewCompat.setOnApplyWindowInsetsListener(
             getWindow().findViewById(android.R.id.content),
             (v, insets) -> {
-                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                Insets systemBars =
+                    insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
                 v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
                 return WindowInsetsCompat.CONSUMED;
             }

--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -78,9 +78,9 @@ public class FeedbackActivity extends AppCompatActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
         setTheme(R.style.ShakyBaseTheme);
-        EdgeToEdge.enable(this);
         ViewCompat.setOnApplyWindowInsetsListener(
             getWindow().findViewById(android.R.id.content),
             (v, insets) -> {

--- a/shaky/src/main/res/values/shaky_styles.xml
+++ b/shaky/src/main/res/values/shaky_styles.xml
@@ -71,8 +71,6 @@
         <item name="alertDialogTheme">?attr/shakyAlertDialogTheme</item>
         <item name="materialAlertDialogTheme">?attr/shakyAlertDialogTheme</item>
 
-        <!-- Opt out of Edge to Edge enforcement required from Android 15 -->
-        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
     <style name="ShakyBasePopupTheme" parent="Theme.AppCompat.Light.Dialog.Alert">


### PR DESCRIPTION
### Summary

Add support for Android 16 edge-to-edge

- Enabled edge-to-edge for FeedbackActivity and sample app.
- Added dependency for `androidx.activity:activity:1.10.1` in `shaky-sample`
  to be bale to get edge to edge support in sample app.
- Used insets to handle edge to edge functionality.
- Made other required changes accordingly.

### Testing Done:
Tested locally. Please refer the attached screenrecordings:

|Theme | Before | After |
| -- | -- |--|
| Light | <video src ="https://github.com/user-attachments/assets/59debb0a-d497-47f5-8bec-475c37365b78"> | <video src="https://github.com/user-attachments/assets/c21a6011-aee0-4a35-bd09-07b05e326205">|
| Dark | <video src = "https://github.com/user-attachments/assets/e01a30f7-9666-4780-ac1e-e7a8a1b9f630"> | <video src="https://github.com/user-attachments/assets/35124ec1-7030-4362-9d88-a5dea34ff065">|


