### PR TITLE
Update code to not delete existing screenshots

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
@@ -54,20 +54,8 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
         if (screenshotDirectoryRoot == null) {
             return null;
         }
-
-        // delete any old screenshots that we may have left lying around
         File screenshotDirectory = new File(screenshotDirectoryRoot);
-        if (screenshotDirectory.exists()) {
-            File[] oldScreenshots = screenshotDirectory.listFiles();
-            for (File oldScreenshot : oldScreenshots) {
-                if (!oldScreenshot.delete()) {
-                    Log.e(TAG, "Could not delete old screenshot:" + oldScreenshot);
-                }
-            }
-        }
-
         Uri screenshotUri = null;
-
         Bitmap bitmap = params != null && params.length != 0 ? params[0] : null;
         if (bitmap != null) {
             File screenshotFile = Utils.writeBitmapToDirectory(bitmap, screenshotDirectory);

--- a/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
@@ -54,7 +54,21 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
         if (screenshotDirectoryRoot == null) {
             return null;
         }
+
         File screenshotDirectory = new File(screenshotDirectoryRoot);
+
+        if(delegate.enableDeletingOldScreenshots()) {
+            // delete any old screenshots that we may have left lying around
+            if (screenshotDirectory.exists()) {
+                File[] oldScreenshots = screenshotDirectory.listFiles();
+                for (File oldScreenshot : oldScreenshots) {
+                    if (!oldScreenshot.delete()) {
+                        Log.e(TAG, "Could not delete old screenshot:" + oldScreenshot);
+                    }
+                }
+            }
+        }
+
         Uri screenshotUri = null;
         Bitmap bitmap = params != null && params.length != 0 ? params[0] : null;
         if (bitmap != null) {

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -22,7 +22,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.StyleRes;
 import androidx.annotation.WorkerThread;
 
 import java.lang.annotation.Retention;
@@ -145,4 +144,14 @@ public abstract class ShakeDelegate {
      * This method can be overridden to send data to a custom URL endpoint, etc.
      */
     public abstract void submit(@NonNull Activity activity, @NonNull Result result);
+
+    /**
+     * @return whether the captured screenshots in memory should be deleted or not before capturing
+     * a new one.
+     * Please note that, when disabled, it is the responsibility of the integrating app to delete
+     * the old screenshots as and when required.
+     */
+    public boolean enableDeletingOldScreenshots() {
+        return true;
+    }
 }


### PR DESCRIPTION
Update code to not delete existing screenshots

- Updated `CollectDataTask` to not delete any existing screenshots.
- This is to avoid failure when trying to access old screenshots in
  scenarios like multiple network requests.