### PR TITLE
Add support for capturing screenshots for modals

### DIFF
--- a/shaky-sample/build.gradle
+++ b/shaky-sample/build.gradle
@@ -28,4 +28,5 @@ dependencies {
     implementation "androidx.annotation:annotation:1.0.0"
     implementation "androidx.core:core:1.6.0"
     implementation "androidx.activity:activity:1.10.1"
+    implementation 'com.google.android.material:material:1.12.0'
 }

--- a/shaky-sample/src/main/AndroidManifest.xml
+++ b/shaky-sample/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
     <!-- for MultipleAttachmentShakeDelegate example -->
     <uses-permission android:name="android.permission.READ_LOGS"
         tools:ignore="ProtectedPermissions" />
+
+    <!-- Permissions required for MediaProjection screen capture -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+
     <application
         android:name=".ShakyApplication"
         android:allowBackup="false"

--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/SampleBottomSheetDialog.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/SampleBottomSheetDialog.java
@@ -1,0 +1,116 @@
+package com.linkedin.android.shaky.app;
+
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+import androidx.core.view.ViewCompat;
+
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+
+/**
+ * A bottom sheet dialog that covers 50% of the screen with sample text.
+ * Includes elevation and styling to appear as an overlay.
+ */
+public class SampleBottomSheetDialog extends BottomSheetDialogFragment {
+
+    private static final float ELEVATION_DP = 16f;
+    private static final float CORNER_RADIUS_DP = 16f;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Apply a style that supports elevation
+        setStyle(BottomSheetDialogFragment.STYLE_NORMAL, R.style.CustomBottomSheetDialog);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        // Create a CardView to contain our content and provide elevation
+        CardView cardView = new CardView(requireContext());
+        cardView.setLayoutParams(new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        // Set CardView properties for elevation effect
+        cardView.setCardElevation(dpToPx(ELEVATION_DP));
+        cardView.setRadius(dpToPx(CORNER_RADIUS_DP));
+        cardView.setCardBackgroundColor(Color.WHITE);
+
+        // Create content TextView
+        TextView textView = new TextView(getContext());
+        textView.setPadding((int)dpToPx(24), (int)dpToPx(32), (int)dpToPx(24), (int)dpToPx(32));
+        textView.setText("This is a sample bottom sheet dialog that covers 50% of the screen.\n\n" +
+                "It demonstrates how Shaky can capture overlay screens using the MediaProjection API.\n\n" +
+                "This dialog has elevation to make it look like an overlay!\n\n" +
+                "Try shaking the device or using the feedback button while this sheet is visible!");
+        textView.setTextSize(18);
+
+        // Add the TextView to the CardView
+        cardView.addView(textView);
+
+        return cardView;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        // Set the height to 50% of screen when the view is created
+        view.getViewTreeObserver().addOnGlobalLayoutListener(() -> {
+            // Get the parent view of the bottom sheet
+            View bottomSheet = (View) view.getParent();
+            // Set up the bottom sheet behavior
+            BottomSheetBehavior<View> behavior = BottomSheetBehavior.from(bottomSheet);
+            // Set the height to 50% of screen
+            behavior.setPeekHeight(getResources().getDisplayMetrics().heightPixels / 2);
+            behavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+        });
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        // Additional setup for the dialog window for elevation effect
+        if (getDialog() != null && getDialog() instanceof BottomSheetDialog) {
+            BottomSheetDialog dialog = (BottomSheetDialog) getDialog();
+
+            // Find the bottom sheet view
+            FrameLayout bottomSheet = dialog.findViewById(com.google.android.material.R.id.design_bottom_sheet);
+            if (bottomSheet != null) {
+                // Set background with rounded top corners
+                GradientDrawable drawable = new GradientDrawable();
+                drawable.setColor(Color.WHITE);
+                drawable.setCornerRadii(new float[]{
+                        dpToPx(CORNER_RADIUS_DP), dpToPx(CORNER_RADIUS_DP),  // top-left
+                        dpToPx(CORNER_RADIUS_DP), dpToPx(CORNER_RADIUS_DP),  // top-right
+                        0, 0,  // bottom-right
+                        0, 0   // bottom-left
+                });
+
+                // Apply the drawable and elevation
+                ViewCompat.setBackground(bottomSheet, drawable);
+                ViewCompat.setElevation(bottomSheet, dpToPx(ELEVATION_DP));
+            }
+        }
+    }
+
+    /**
+     * Convert dp to pixels
+     */
+    private float dpToPx(float dp) {
+        return dp * getResources().getDisplayMetrics().density;
+    }
+}

--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -15,7 +15,8 @@
  */
 package com.linkedin.android.shaky.app;
 
-import android.app.Activity;
+import androidx.fragment.app.FragmentActivity;
+import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
@@ -26,11 +27,13 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.linkedin.android.shaky.ActionConstants;
+import com.linkedin.android.shaky.Shaky;
 
 import java.util.Random;
 
-public class ShakyDemo extends Activity {
+public class ShakyDemo extends FragmentActivity {
 
     private static final int RGB_MAX = 256;
 
@@ -76,6 +79,11 @@ public class ShakyDemo extends Activity {
             }
         });
 
+        findViewById(R.id.open_bottom_sheet_button).setOnClickListener(v -> {
+            SampleBottomSheetDialog bottomSheetDialogFragment = new SampleBottomSheetDialog();
+            bottomSheetDialogFragment.show(this.getSupportFragmentManager(), bottomSheetDialogFragment.getTag());
+        });
+
         findViewById(R.id.demo_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -90,5 +98,16 @@ public class ShakyDemo extends Activity {
                         .startFeedbackFlow(ActionConstants.ACTION_START_BUG_REPORT);
             }
         });
+
+        ((ShakyApplication)getApplication()).getShaky().setUseMediaProjection(true);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Shaky shaky = ((ShakyApplication) getApplication()).getShaky();
+        if (!shaky.handleActivityResult(requestCode, resultCode, data)) {
+            // If Shaky did not handle the result, call the super method
+            super.onActivityResult(requestCode, resultCode, data);
+        }
     }
 }

--- a/shaky-sample/src/main/res/layout/activity_demo.xml
+++ b/shaky-sample/src/main/res/layout/activity_demo.xml
@@ -44,6 +44,13 @@
         android:text="@string/manual_feedback_trigger"/>
 
     <Button
+        android:id="@+id/open_bottom_sheet_button"
+        style="?attr/borderlessButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/open_bottom_sheet"/>
+
+    <Button
         android:id="@+id/demo_bug_report_button"
         style="?attr/borderlessButtonStyle"
         android:layout_width="match_parent"

--- a/shaky-sample/src/main/res/values/strings.xml
+++ b/shaky-sample/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name" translatable="false">Shaky</string>
     <string name="shake_me" translatable="false">Shake me!</string>
     <string name="manual_feedback_trigger" translatable="false">Manually start feedback</string>
+    <string name="open_bottom_sheet" translatable="false">Open Bottom Sheet modal</string>
     <string name="manual_bug_report" translatable="false">Manually start bug report</string>
     <string name="show_toast" translatable="false">Show Toast</string>
     <string name="toast_text" translatable="false">This is a toast.</string>

--- a/shaky-sample/src/main/res/values/styles.xml
+++ b/shaky-sample/src/main/res/values/styles.xml
@@ -11,6 +11,25 @@
         <item name="windowActionBar">false</item>
     </style>
 
+    <!-- Custom BottomSheetDialog style with elevation -->
+    <style name="CustomBottomSheetDialog" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+        <item name="bottomSheetStyle">@style/CustomBottomSheet</item>
+    </style>
+
+    <style name="CustomBottomSheet" parent="Widget.MaterialComponents.BottomSheet">
+        <item name="android:background">@android:color/transparent</item>
+        <item name="shapeAppearanceOverlay">@style/CustomShapeAppearanceBottomSheetDialog</item>
+    </style>
+
+    <style name="CustomShapeAppearanceBottomSheetDialog" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSizeTopRight">16dp</item>
+        <item name="cornerSizeTopLeft">16dp</item>
+    </style>
+
     <style name="ShakyChristmasToolbarTheme" parent="@style/ShakyBaseToolbarTheme">
         <item name="android:background">@color/red</item>
     </style>

--- a/shaky/src/main/AndroidManifest.xml
+++ b/shaky/src/main/AndroidManifest.xml
@@ -16,7 +16,19 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Permission for foreground service -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Permission specifically for media projection foreground service type on Android 10+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+
     <application android:supportsRtl="true">
         <activity android:name="com.linkedin.android.shaky.FeedbackActivity" />
+
+        <!-- Foreground service for MediaProjection -->
+        <service
+            android:name=".ScreenCaptureService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
     </application>
 </manifest>

--- a/shaky/src/main/java/com/linkedin/android/shaky/ScreenCaptureManager.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ScreenCaptureManager.java
@@ -1,0 +1,208 @@
+package com.linkedin.android.shaky;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.PixelFormat;
+import android.hardware.display.DisplayManager;
+import android.hardware.display.VirtualDisplay;
+import android.media.Image;
+import android.media.ImageReader;
+import android.media.projection.MediaProjection;
+import android.media.projection.MediaProjectionManager;
+import android.os.Build;
+import android.os.Handler;
+import android.view.Display;
+import android.view.WindowManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Manages screen capture operations using MediaProjection API.
+ * This class handles the permission request and screen capturing process.
+ */
+public class ScreenCaptureManager {
+
+    private static final int REQUEST_CODE_MEDIA_PROJECTION = 1000;
+
+    private Context appContext;
+    private MediaProjectionManager projectionManager;
+    private MediaProjection mediaProjection;
+    private VirtualDisplay virtualDisplay;
+    private ImageReader imageReader;
+    private int screenWidth;
+    private int screenHeight;
+    private int screenDensity;
+
+    private CaptureCallback captureCallback;
+
+    public interface CaptureCallback {
+        void onCaptureComplete(Bitmap bitmap);
+        void onCaptureFailed();
+    }
+
+    public ScreenCaptureManager(Context context) {
+        this.appContext = context.getApplicationContext();
+        projectionManager = (MediaProjectionManager)
+                appContext.getSystemService(Context.MEDIA_PROJECTION_SERVICE);
+    }
+
+    /**
+     * Request screen capture permission and start the capturing process.
+     * This needs to be called from an Activity.
+     *
+     * @param activity Activity to request permission from
+     * @param callback Callback to receive the captured screenshot or failure
+     */
+    public void requestCapturePermission(Activity activity, CaptureCallback callback) {
+        if (activity == null || callback == null) {
+            return;
+        }
+
+        this.captureCallback = callback;
+
+        // Get screen metrics
+        WindowManager windowManager = (WindowManager) activity.getSystemService(Context.WINDOW_SERVICE);
+        Display display = windowManager.getDefaultDisplay();
+        android.util.DisplayMetrics metrics = new android.util.DisplayMetrics();
+        display.getMetrics(metrics);
+
+        screenWidth = metrics.widthPixels;
+        screenHeight = metrics.heightPixels;
+        screenDensity = metrics.densityDpi;
+
+        // Request permission
+        Intent intent = projectionManager.createScreenCaptureIntent();
+        activity.startActivityForResult(intent, REQUEST_CODE_MEDIA_PROJECTION);
+    }
+
+    /**
+     * Handle activity result from permission request.
+     * This should be called from the activity's onActivityResult method.
+     *
+     * @param requestCode Request code from onActivityResult
+     * @param resultCode Result code from onActivityResult
+     * @param data Intent data from onActivityResult
+     * @return true if handled by this manager, false otherwise
+     */
+    public boolean handleActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode != REQUEST_CODE_MEDIA_PROJECTION) {
+            return false;
+        }
+
+        if (resultCode == Activity.RESULT_OK && data != null) {
+            // Start the foreground service before creating MediaProjection
+            ScreenCaptureService.start(appContext);
+
+            // Wait briefly to ensure the service is fully started
+            new Handler().postDelayed(() -> {
+                startCapture(resultCode, data);
+            }, 100); // Small delay to ensure service starts
+            return true;
+        } else {
+            if (captureCallback != null) {
+                captureCallback.onCaptureFailed();
+            }
+            return true;
+        }
+    }
+
+    private void startCapture(int resultCode, Intent data) {
+        mediaProjection = projectionManager.getMediaProjection(resultCode, data);
+
+        imageReader = ImageReader.newInstance(
+                screenWidth, screenHeight,
+                PixelFormat.RGBA_8888, 2);
+
+        virtualDisplay = mediaProjection.createVirtualDisplay(
+                "Shaky Screenshot",
+                screenWidth, screenHeight, screenDensity,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+                imageReader.getSurface(), null, null);
+
+        // Capture the image with a delay to ensure display is ready
+        new Handler().postDelayed(() -> captureImage(), 100);
+    }
+
+    private void captureImage() {
+        if (imageReader == null) {
+            if (captureCallback != null) {
+                captureCallback.onCaptureFailed();
+            }
+            stopCapture();
+            return;
+        }
+
+        Image image = null;
+        try {
+            image = imageReader.acquireLatestImage();
+            if (image == null) {
+                if (captureCallback != null) {
+                    captureCallback.onCaptureFailed();
+                }
+                stopCapture();
+                return;
+            }
+
+            final Image.Plane[] planes = image.getPlanes();
+            final ByteBuffer buffer = planes[0].getBuffer();
+
+            int pixelStride = planes[0].getPixelStride();
+            int rowStride = planes[0].getRowStride();
+            int rowPadding = rowStride - pixelStride * screenWidth;
+
+            // Create bitmap
+            Bitmap bitmap = Bitmap.createBitmap(
+                    screenWidth + rowPadding / pixelStride,
+                    screenHeight,
+                    Bitmap.Config.ARGB_8888);
+            bitmap.copyPixelsFromBuffer(buffer);
+
+            // Crop if needed due to rowPadding
+            Bitmap croppedBitmap = Bitmap.createBitmap(
+                    bitmap, 0, 0, screenWidth, screenHeight);
+
+            if (bitmap != croppedBitmap) {
+                bitmap.recycle();
+            }
+
+            if (captureCallback != null) {
+                captureCallback.onCaptureComplete(croppedBitmap);
+            }
+
+        } catch (Exception e) {
+            if (captureCallback != null) {
+                captureCallback.onCaptureFailed();
+            }
+        } finally {
+            if (image != null) {
+                image.close();
+            }
+            stopCapture();
+        }
+    }
+
+    private void stopCapture() {
+        if (virtualDisplay != null) {
+            virtualDisplay.release();
+            virtualDisplay = null;
+        }
+
+        if (mediaProjection != null) {
+            mediaProjection.stop();
+            mediaProjection = null;
+        }
+
+        if (imageReader != null) {
+            imageReader.close();
+            imageReader = null;
+        }
+
+        // Stop the foreground service
+        ScreenCaptureService.stop(appContext);
+    }
+}

--- a/shaky/src/main/java/com/linkedin/android/shaky/ScreenCaptureService.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ScreenCaptureService.java
@@ -1,0 +1,101 @@
+package com.linkedin.android.shaky;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+/**
+ * Foreground service required for Media Projection API
+ * starting from Android 10.
+ */
+public class ScreenCaptureService extends Service {
+
+    public static final String NOTIFICATION_CHANNEL_ID = "ShakyScreenCapture";
+    private static final int NOTIFICATION_ID = 1001;
+    private static final String ACTION_START = "com.linkedin.android.shaky.action.START_CAPTURE";
+    private static final String ACTION_STOP = "com.linkedin.android.shaky.action.STOP_CAPTURE";
+
+    /**
+     * Starts the foreground service for screen capture
+     *
+     * @param context Application context
+     */
+    public static void start(Context context) {
+        Intent intent = new Intent(context, ScreenCaptureService.class);
+        intent.setAction(ACTION_START);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
+    }
+
+    /**
+     * Stops the foreground service
+     *
+     * @param context Application context
+     */
+    public static void stop(Context context) {
+        Intent intent = new Intent(context, ScreenCaptureService.class);
+        intent.setAction(ACTION_STOP);
+        context.startService(intent);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null && ACTION_START.equals(intent.getAction())) {
+            createNotificationChannel();
+            startForeground(NOTIFICATION_ID, createNotification());
+        } else if (intent != null && ACTION_STOP.equals(intent.getAction())) {
+            stopForeground(true);
+            stopSelf();
+        }
+
+        return START_NOT_STICKY;
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    "Screen Capture",
+                    NotificationManager.IMPORTANCE_LOW);
+            channel.setDescription("Used for capturing screenshots");
+
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            if (notificationManager != null) {
+                notificationManager.createNotificationChannel(channel);
+            }
+        }
+    }
+
+    private Notification createNotification() {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+                .setContentTitle("Capturing Screenshot")
+                .setContentText("Processing your feedback...")
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setSmallIcon(android.R.drawable.ic_menu_camera);
+
+        // Set the correct foreground service type for MediaProjection
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            builder.setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE);
+        }
+
+        return builder.build();
+    }
+}


### PR DESCRIPTION
Add support to capture screenshots for modals which are linked to window root view rather than activity root view.

Requires adding more permissions for capturing screenshots using MediaProjectionManager API:
MEDIA_PROJECTION_SERVICE

Before adding support for this API:
<img width="327" alt="Screenshot 2025-06-20 at 2 14 53 PM" src="https://github.com/user-attachments/assets/34639df7-1c9a-446d-9108-290b21950513" />

After adding support for this API:
<img width="323" alt="Screenshot 2025-06-20 at 2 13 29 PM" src="https://github.com/user-attachments/assets/8d6e28d3-c559-4f46-b942-2bad0fa68b94" />

