### PR TITLE
Add callback to fix crash

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/ScreenCaptureManager.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ScreenCaptureManager.java
@@ -111,8 +111,17 @@ public class ScreenCaptureManager {
         }
     }
 
+    private final MediaProjection.Callback mediaProjectionCallback = new MediaProjection.Callback() {
+        @Override
+        public void onStop() {
+            stopCapture();
+        }
+    };
+
     private void startCapture(int resultCode, Intent data) {
         mediaProjection = projectionManager.getMediaProjection(resultCode, data);
+        // Register callback to manage resources
+        mediaProjection.registerCallback(mediaProjectionCallback, new Handler());
 
         imageReader = ImageReader.newInstance(
                 screenWidth, screenHeight,


### PR DESCRIPTION
```java.lang.IllegalStateException: Must register a callback before starting capture, to manage resources in response to MediaProjection states.```

Adding callback prevents this crash.