### PR TITLE
Cleanup unused code added to not delete existing screenshots

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/CollectDataTask.java
@@ -57,14 +57,12 @@ class CollectDataTask extends AsyncTask<Bitmap, Void, Result> {
 
         File screenshotDirectory = new File(screenshotDirectoryRoot);
 
-        if(delegate.enableDeletingOldScreenshots()) {
-            // delete any old screenshots that we may have left lying around
-            if (screenshotDirectory.exists()) {
-                File[] oldScreenshots = screenshotDirectory.listFiles();
-                for (File oldScreenshot : oldScreenshots) {
-                    if (!oldScreenshot.delete()) {
-                        Log.e(TAG, "Could not delete old screenshot:" + oldScreenshot);
-                    }
+        // delete any old screenshots that we may have left lying around
+        if (screenshotDirectory.exists()) {
+            File[] oldScreenshots = screenshotDirectory.listFiles();
+            for (File oldScreenshot : oldScreenshots) {
+                if (!oldScreenshot.delete()) {
+                    Log.e(TAG, "Could not delete old screenshot:" + oldScreenshot);
                 }
             }
         }

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -144,14 +144,4 @@ public abstract class ShakeDelegate {
      * This method can be overridden to send data to a custom URL endpoint, etc.
      */
     public abstract void submit(@NonNull Activity activity, @NonNull Result result);
-
-    /**
-     * @return whether the captured screenshots in memory should be deleted or not before capturing
-     * a new one.
-     * Please note that, when disabled, it is the responsibility of the integrating app to delete
-     * the old screenshots as and when required.
-     */
-    public boolean enableDeletingOldScreenshots() {
-        return true;
-    }
 }


### PR DESCRIPTION
### Summary
- This PR cleans up the now unused code added under [PR#80.](https://github.com/linkedin/shaky-android/pull/80)
- Removed method `ShakeDelegate#enableDeletingOldScreenshots()` used to determine enabling/disabling deletion of old screenshots.
- Also deleted related code usages.


### Testing Done
- Tested locally.