### PR TITLE
Create bottom sheet for shake-to-feedback and launch them when shake is detected

### DIFF
--- a/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
+++ b/shaky-sample/src/main/java/com/linkedin/android/shaky/app/ShakyDemo.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.android.shaky.app;
 
-import androidx.fragment.app.FragmentActivity;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -26,8 +25,8 @@ import android.widget.Toast;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.fragment.app.FragmentActivity;
 
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.linkedin.android.shaky.ActionConstants;
 import com.linkedin.android.shaky.Shaky;
 
@@ -96,6 +95,13 @@ public class ShakyDemo extends FragmentActivity {
             public void onClick(View v) {
                 ((ShakyApplication) getApplication()).getShaky()
                         .startFeedbackFlow(ActionConstants.ACTION_START_BUG_REPORT);
+            }
+        });
+
+        findViewById(R.id.demo_bottom_sheet_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ((ShakyApplication) getApplication()).getShaky().startShakeBottomSheetFlowManually();
             }
         });
 

--- a/shaky-sample/src/main/res/layout/activity_demo.xml
+++ b/shaky-sample/src/main/res/layout/activity_demo.xml
@@ -57,4 +57,11 @@
         android:layout_height="wrap_content"
         android:text="@string/manual_bug_report"/>
 
+    <Button
+        android:id="@+id/demo_bottom_sheet_button"
+        style="?attr/borderlessButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/manual_bottom_sheet"/>
+
 </LinearLayout>

--- a/shaky-sample/src/main/res/values/strings.xml
+++ b/shaky-sample/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="manual_feedback_trigger" translatable="false">Manually start feedback</string>
     <string name="open_bottom_sheet" translatable="false">Open Bottom Sheet modal</string>
     <string name="manual_bug_report" translatable="false">Manually start bug report</string>
+    <string name="manual_bottom_sheet" translatable="false">Manually launch bottom sheet</string>
     <string name="show_toast" translatable="false">Show Toast</string>
     <string name="toast_text" translatable="false">This is a toast.</string>
     <string name="christmas_theme" translatable="false">Use Christmas theme</string>

--- a/shaky/src/main/java/com/linkedin/android/shaky/ActionConstants.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ActionConstants.java
@@ -22,5 +22,7 @@ public class ActionConstants {
 
     public static final String ACTION_START_FEEDBACK_FLOW = "StartFeedbackFlow";
     public static final String ACTION_START_BUG_REPORT = "StartBugReport";
+    public static final String ACTION_START_GENERAL_FEEDBACK = "StartGeneralFeedback";
     public static final String ACTION_DIALOG_DISMISSED_BY_USER = "DialogDismissedByUser";
+    public static final String ACTION_DISMISS = "Dismiss";
 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/BottomSheetFeedbackItem.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/BottomSheetFeedbackItem.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.android.shaky;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Data wrapper for a single row in the select feedback type view.
+ */
+class BottomSheetFeedbackItem {
+    @IntDef({
+            BUG,
+            GENERAL,
+            DISMISS
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface FeedbackType {}
+
+    public static final int BUG = 0;
+    public static final int GENERAL = 2;
+    public static final int DISMISS = 3;
+
+    @DrawableRes public final int icon;
+    public final String title;
+    public final String description;
+    public final int feedbackType;
+    public final String action;
+
+    BottomSheetFeedbackItem(@NonNull String title,
+                            @NonNull String description,
+                            @DrawableRes int icon,
+                            @FeedbackType int feedbackType,
+                            @NonNull String action) {
+        this.title = title;
+        this.description = description;
+        this.icon = icon;
+        this.feedbackType = feedbackType;
+        this.action = action;
+    }
+}

--- a/shaky/src/main/java/com/linkedin/android/shaky/BottomSheetFeedbackTypeAdapter.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/BottomSheetFeedbackTypeAdapter.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2016 LinkedIn Corp.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.android.shaky;
+
+import android.content.Intent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StyleRes;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.bottomsheet.BottomSheetDialog;
+
+/**
+ * RecyclerView.Adapter for the select type of feedback view.
+ */
+class BottomSheetFeedbackTypeAdapter extends RecyclerView.Adapter<BottomSheetFeedbackTypeAdapter.RowViewHolder> {
+
+    public static final String EXTRA_FEEDBACK_TYPE = "ExtraFeedbackType";
+    private static final int DISMISS_OPTION_POSITION = 2;
+    private final BottomSheetFeedbackItem[] itemsList;
+    @NonNull
+    private final BottomSheetDialog bottomSheetFeedbackFragment;
+
+    @StyleRes
+    private final int theme;
+
+    BottomSheetFeedbackTypeAdapter(@NonNull BottomSheetFeedbackItem[] itemsList,
+                                   @NonNull BottomSheetDialog bottomSheetFeedbackFragment,
+                                   @StyleRes int theme) {
+        this.itemsList = itemsList;
+        this.bottomSheetFeedbackFragment = bottomSheetFeedbackFragment;
+        this.theme = theme;
+    }
+
+    @Override
+    public int getItemCount() {
+        return itemsList.length;
+    }
+
+    @NonNull
+    @Override
+    public RowViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        LayoutInflater inflater = Utils.applyThemeToInflater(LayoutInflater.from(viewGroup.getContext()), theme);
+        View view = inflater.inflate(R.layout.shaky_single_row, viewGroup, false);
+        return new RowViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(RowViewHolder rowViewHolder, int position) {
+        final BottomSheetFeedbackItem item = itemsList[position];
+
+        rowViewHolder.titleView.setText(item.title);
+        rowViewHolder.descriptionView.setText(item.description);
+        rowViewHolder.imageView.setImageResource(item.icon);
+        rowViewHolder.itemView.setOnClickListener(v -> {
+            // Dismiss is clicked
+            if (position == DISMISS_OPTION_POSITION) {
+                bottomSheetFeedbackFragment.dismiss();
+                return;
+            }
+            Intent intent = new Intent(item.action);
+            intent.putExtra(EXTRA_FEEDBACK_TYPE, item.feedbackType);
+            LocalBroadcastManager.getInstance(v.getContext()).sendBroadcast(intent);
+            bottomSheetFeedbackFragment.dismiss();
+        });
+    }
+
+    static class RowViewHolder extends RecyclerView.ViewHolder {
+        public final ImageView imageView;
+        public final TextView titleView;
+        public final TextView descriptionView;
+
+        RowViewHolder(@NonNull View itemView) {
+            super(itemView);
+            this.imageView = itemView.findViewById(R.id.shaky_row_icon);
+            this.titleView = itemView.findViewById(R.id.shaky_row_title);
+            this.descriptionView = itemView.findViewById(R.id.shaky_row_description);
+        }
+    }
+}

--- a/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/FeedbackActivity.java
@@ -106,9 +106,8 @@ public class FeedbackActivity extends AppCompatActivity {
                     .commit();
             } else if (action.equals(ActionConstants.ACTION_START_BUG_REPORT)) {
                 startFormFragment(FeedbackItem.BUG, false);
-                if (imageUri != null) {
-                    startDrawFragment();
-                }
+            } else if (action.equals(ActionConstants.ACTION_START_GENERAL_FEEDBACK)) {
+                startFormFragment(FeedbackItem.GENERAL, false);
             }
         }
     }

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -123,6 +123,15 @@ public abstract class ShakeDelegate {
     }
 
     /**
+     * @return a custom theme to apply to the bottom sheet that appears when the user shakes. Look
+     * at shaky_attrs.xml for possible attributes to set
+     */
+    @Nullable
+    public Integer getBottomSheetTheme() {
+        return null;
+    }
+
+    /**
      * Called from the background thread during the feedback collection flow. This method
      * can be used to collect extra debug information to include in the feedback
      * submission, such as user data, app version, etc.
@@ -137,6 +146,13 @@ public abstract class ShakeDelegate {
     @Nullable
     public DialogFragment getCustomDialog() {
         return null;
+    }
+
+    /**
+     * @return if the dialog should be shown on shake or the shake-to-feedback bottom sheet.
+     */
+    public boolean shouldUseBottomSheet() {
+        return true;
     }
 
     /**

--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -126,9 +126,8 @@ public abstract class ShakeDelegate {
      * @return a custom theme to apply to the bottom sheet that appears when the user shakes. Look
      * at shaky_attrs.xml for possible attributes to set
      */
-    @Nullable
-    public Integer getBottomSheetTheme() {
-        return null;
+    public int getBottomSheetTheme() {
+        return R.style.ShakyBaseBottomSheetTheme;
     }
 
     /**

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -278,18 +278,18 @@ public class Shaky implements ShakeDetector.Listener {
         if (delegate.shouldUseBottomSheet()) {
             if (activity != null) {
                 BottomSheetDialog bottomSheetDialog;
-                if (delegate.getBottomSheetTheme() != null) {
-                    bottomSheetDialog = new BottomSheetDialog(activity, delegate.getBottomSheetTheme());
-                } else {
-                    bottomSheetDialog = new BottomSheetDialog(activity, R.style.ShakyBaseBottomSheetTheme);
-                }
+                bottomSheetDialog = new BottomSheetDialog(activity, delegate.getBottomSheetTheme());
 
                 View sheetView = LayoutInflater.from(activity).inflate(R.layout.shaky_feedback_bottomsheet, null);
 
                 RecyclerView recyclerView = sheetView.findViewById(R.id.shaky_recyclerView_bottomsheet);
                 recyclerView.setLayoutManager(new LinearLayoutManager(activity));
-                int bottomSheetTheme = delegate.getBottomSheetTheme() == null ? R.style.ShakyBaseBottomSheetTheme : delegate.getBottomSheetTheme();
-                recyclerView.setAdapter(new BottomSheetFeedbackTypeAdapter(getData(activity), bottomSheetDialog, bottomSheetTheme));
+                recyclerView.setAdapter(
+                        new BottomSheetFeedbackTypeAdapter(
+                                getData(activity),
+                                bottomSheetDialog,
+                                delegate.getBottomSheetTheme())
+                );
 
                 bottomSheetDialog.setContentView(sheetView);
                 bottomSheetDialog.show();

--- a/shaky/src/main/res/drawable-hdpi/shaky_dismiss.xml
+++ b/shaky/src/main/res/drawable-hdpi/shaky_dismiss.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="91"
+    android:viewportHeight="169.59375">
+    <group android:scaleX="0.24682513"
+        android:scaleY="0.46"
+        android:translateX="34.269455"
+        android:translateY="45.790314">
+        <group android:translateY="139.21875">
+            <path android:pathData="M6.2578125,0L43.875,-55.40625L40.851562,-45.632812L40.851562,-51.257812L6.6796875,-101.46094L21.9375,-101.46094L49.078125,-60.609375L54.84375,-60.609375L46.476562,-56.109375L76.921875,-101.46094L91.33594,-101.46094L56.25,-50.625L56.25,-45L53.226562,-54.773438L90.5625,0L75.375,0L48.375,-40.5L42.609375,-40.5L50.976562,-44.929688L20.601562,0Z"
+                android:fillColor="#000000"/>
+        </group>
+    </group>
+</vector>

--- a/shaky/src/main/res/layout/shaky_feedback_bottomsheet.xml
+++ b/shaky/src/main/res/layout/shaky_feedback_bottomsheet.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/shaky_recyclerView_bottomsheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/shaky_content_top_padding"/>
+
+</LinearLayout>

--- a/shaky/src/main/res/layout/shaky_single_row.xml
+++ b/shaky/src/main/res/layout/shaky_single_row.xml
@@ -27,7 +27,7 @@
 
     <ImageView
         android:id="@+id/shaky_row_icon"
-        android:layout_width="wrap_content"
+        android:layout_width="@dimen/shaky_icon_width"
         android:layout_height="match_parent"
         android:layout_margin="@dimen/shaky_icon_padding"
         android:adjustViewBounds="true"

--- a/shaky/src/main/res/values/shaky_dimens.xml
+++ b/shaky/src/main/res/values/shaky_dimens.xml
@@ -22,6 +22,7 @@
     <dimen name="shaky_content_top_padding">8dp</dimen>
     <dimen name="shaky_section_padding">16dp</dimen>
     <dimen name="shaky_icon_padding">8dp</dimen>
+    <dimen name="shaky_icon_width">56dp</dimen>
 
     <!-- textsize -->
     <dimen name="shaky_title_textsize">20sp</dimen>

--- a/shaky/src/main/res/values/shaky_strings.xml
+++ b/shaky/src/main/res/values/shaky_strings.xml
@@ -43,6 +43,10 @@
     <string name="shaky_message_hint">Write your feedback</string>
     <string name="shaky_image_action">Tap to edit image</string>
 
+<!-- Marking non-translatable for now, until we receive translated strings from the team -->
+    <string name="shaky_dismiss_title" translatable="false">Dismiss</string>
+    <string name="shaky_dismiss_subtitle" translatable="false">Exit shaky</string>
+
     <string name="shaky_form_submit">Send</string>
 
     <string name="shaky_draw_hint">Please mark the affected area(s)</string>

--- a/shaky/src/main/res/values/shaky_styles.xml
+++ b/shaky/src/main/res/values/shaky_styles.xml
@@ -82,4 +82,19 @@
         <item name="colorAccent">?attr/shakyPopupButtonColor</item>
         <item name="colorBackgroundFloating">?attr/shakyPopupBackgroundColor</item>
     </style>
+
+    <style name="ShakyBaseBottomSheetTheme" parent="Theme.Material3.DayNight.BottomSheetDialog">
+        <!-- Common -->
+        <item name="shakyBackgroundColor">@android:color/white</item>
+        <item name="shakyTitleColor">@color/shaky_dark_gray</item>
+        <item name="shakyContentColor">@color/shaky_gray</item>
+
+        <!-- Category Select -->
+        <item name="shakySelectBackgroundColor">?attr/shakyBackgroundColor</item>
+        <item name="shakyCategoryListItemTitleColor">?attr/shakyTitleColor</item>
+        <item name="shakyCategoryListItemSubtitleColor">?attr/shakyContentColor</item>
+
+        <!-- Bottom sheet background color -->
+        <item name="colorSurfaceContainerLow">?attr/shakyBackgroundColor</item>
+    </style>
 </resources>


### PR DESCRIPTION
### Summary
Create bottom sheet for shake-to-feedback and launch them when shake is detected

- Created following supporting files for handling bottom sheet support:
    - `BottomSheetFeedbackItem`: data wrapper to store content to be displayed for single row in bottomsheet.
    - `BottomSheetFeedbackTypeAdapter`: RecyclerView.Adapter for the select type of feedback view.
    - `shaky_feedback_bottomsheet`: bottomsheet's xml containing RV to show options.
    - `shaky_dismiss`: Dismiss icon.
- Added support in `Shaky` to detect shake and launch bottom sheet accordingly.
- Made changes to manually launch the bottom sheet in the sample app by adding a button on the main screen i.e. `activity_demo.xml`.
- Updated `ShakyApplication` and `ShakeDelegate` to add methods for setting theme and boolean to handle bottomsheet support launch.
- Added constants for dismiss and feedback actions in `ActionConstants`.
- Added support to launch form fragment with `FeedbackItem.GENERAL` on `ACTION_START_GENERAL_FEEDBACK`.
- Also added styles, string, and dimen resources as required.

### Testing Done
Tested locally. Please refer the attached screenshots and recordings.

**Screenshots**

| Scenario | Before | After |
| -- | -- | -- |
| Sample app Home Screen | <img width="1080" height="2400" alt="before_main_screen" src="https://github.com/user-attachments/assets/7557a6a3-ba67-4c7d-b63a-21629aecc1b6" /> | <img width="1080" height="2400" alt="after_main_screen" src="https://github.com/user-attachments/assets/914434bb-263d-401a-a388-275308966d8c" /> |
| Feedback option screen | <img width="1080" height="2400" alt="before_feedback_screen" src="https://github.com/user-attachments/assets/6be77be3-eec1-41a5-b621-41be9c4c74f3" /> | <img width="1080" height="2400" alt="after_feedback_bottomsheet" src="https://github.com/user-attachments/assets/453dd731-f078-4516-8c05-84bee49f5761" /> |

**Videos**

| Scenario | Before | After |
| -- | -- | -- |
| Manual flow | <video src="https://github.com/user-attachments/assets/7134323d-87b2-4895-86af-89f815e13655"/> | <video src="https://github.com/user-attachments/assets/16d64595-036b-485b-a66c-3abb42d9d416"/> |
| Shake detected flow | <video src="https://github.com/user-attachments/assets/defce776-5f33-4b9a-9f1c-8be330d076f6"/> | <video src="https://github.com/user-attachments/assets/f1c6096c-0a71-477e-a0a9-064b74cf0b9b"/> |
