### PR TITLE
Add support to send feedback title for bottomsheet flow

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/BottomSheetFeedbackTypeAdapter.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/BottomSheetFeedbackTypeAdapter.java
@@ -23,6 +23,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -34,7 +35,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog;
  */
 class BottomSheetFeedbackTypeAdapter extends RecyclerView.Adapter<BottomSheetFeedbackTypeAdapter.RowViewHolder> {
 
-    public static final String EXTRA_FEEDBACK_TYPE = "ExtraFeedbackType";
+    public static final String EXTRA_FEEDBACK_TITLE = "ExtraFeedbackTitle";
     private static final int DISMISS_OPTION_POSITION = 2;
     private final BottomSheetFeedbackItem[] itemsList;
     @NonNull
@@ -78,7 +79,10 @@ class BottomSheetFeedbackTypeAdapter extends RecyclerView.Adapter<BottomSheetFee
                 return;
             }
             Intent intent = new Intent(item.action);
-            intent.putExtra(EXTRA_FEEDBACK_TYPE, item.feedbackType);
+            intent.putExtra(
+                    EXTRA_FEEDBACK_TITLE,
+                    rowViewHolder.titleView.getResources().getString(getTitleResId(item.feedbackType))
+            );
             LocalBroadcastManager.getInstance(v.getContext()).sendBroadcast(intent);
             bottomSheetFeedbackFragment.dismiss();
         });
@@ -95,5 +99,13 @@ class BottomSheetFeedbackTypeAdapter extends RecyclerView.Adapter<BottomSheetFee
             this.titleView = itemView.findViewById(R.id.shaky_row_title);
             this.descriptionView = itemView.findViewById(R.id.shaky_row_description);
         }
+    }
+
+    @StringRes
+    private int getTitleResId(@BottomSheetFeedbackItem.FeedbackType int feedbackType) {
+        if (feedbackType == BottomSheetFeedbackItem.BUG) {
+            return R.string.shaky_bug_title;
+        }
+        return R.string.shaky_general_title;
     }
 }

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -68,6 +68,8 @@ public class Shaky implements ShakeDetector.Listener {
     private boolean useMediaProjection = false;
     private boolean isScreenCaptureInProgress = false;
     private boolean isBottomSheetFlowActive = false;
+    @Nullable
+    private String feedbackTitle;
     private CollectDataTask.Callback pendingDataCollectionCallback = null;
 
     @Nullable
@@ -451,6 +453,11 @@ public class Shaky implements ShakeDetector.Listener {
                         || ActionConstants.ACTION_START_GENERAL_FEEDBACK.equals(intent.getAction())) {
                     if (activity != null) {
                         actionThatStartedTheActivity = intent.getAction();
+                        if (isBottomSheetFlowActive) {
+                            feedbackTitle = intent.getStringExtra(
+                                    BottomSheetFeedbackTypeAdapter.EXTRA_FEEDBACK_TITLE
+                            );
+                        }
                         doStartFeedbackFlow();
                     }
                 } else if (ActionConstants.ACTION_DIALOG_DISMISSED_BY_USER.equals(intent.getAction())
@@ -493,6 +500,8 @@ public class Shaky implements ShakeDetector.Listener {
                     return;
                 } else {
                     if (activity != null) {
+                       safeResult.setTitle(feedbackTitle);
+
                         // add file provider data to all attachments
                         ArrayList<Uri> secureAttachments = new ArrayList<>();
                         for (Uri attachment : safeResult.getAttachments()) {
@@ -500,6 +509,8 @@ public class Shaky implements ShakeDetector.Listener {
                         }
                         safeResult.setAttachments(secureAttachments);
                         delegate.submit(activity, safeResult);
+                        // reset the value to avoid any inconsistent behaviour
+                        isBottomSheetFlowActive = false;
                         return;
                     }
                 }


### PR DESCRIPTION
### Summary
- In bottomsheet flow, users can choose between `Report a bug` and `Send app feedback`. 
- Per previous flow (when user was navigated to `Form/Draw` screen  as per option selected in bottomsheet), it was required to send title that would identify which option is being selected in the bottomsheet.
- Currently, only attachments are being sent in `Result`, while no value is set for the title field.

### Support Added:
- Added support `BottomSheetFeedbackItem#getTitleResId` to get title based on `BottomSheetFeedbackItem` feedback type.
- Added a new key `BottomSheetFeedbackTypeAdapter#EXTRA_FEEDBACK_TITLE` to pass the value of title in intent using the newly added method.
- Added support to fetch value of feedback title when bottomsheet flow is active upon receiving the broadcast in `Shaky#createReceiver`.
- Further, the value of feedback title is set in `safeResult.setTitle`, before the result is submitted.
- Also, removed key `BottomSheetFeedbackTypeAdapter#EXTRA_FEEDBACK_TYPE` as it has no usage in the bottomsheet flow.

### Testing Done

- Tested locally.