### PR TITLE
Enable data collection in custom action

### DIFF
--- a/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/ShakeDelegate.java
@@ -171,10 +171,31 @@ public abstract class ShakeDelegate {
     }
 
     /**
-     * This method can be overridden to provide custom action to be performed on shake when
-     * {@link #enableCustomHandlingOfShake} is enabled.
+     * Called immediately when shake is detected and custom handling is enabled.
+     *
+     * @param activity the current activity
+     * @deprecated Use {@link #performCustomActionOnShake(Activity, Result)} instead.
+     *             This method is called before data collection and does not provide access
+     *             to screenshots or collected debug data. The new method is called after
+     *             data collection completes with full access to the Result object.
      */
-    public void performCustomActionOnShake(@NonNull Activity activity){}
+    @Deprecated
+    public void performCustomActionOnShake(@NonNull Activity activity) {
+        // Default: do nothing
+    }
+
+    /**
+     * Called after data collection is complete when custom shake handling is enabled.
+     * Override this method to perform custom actions with access to collected data including
+     * screenshots, debug info, and attachments.
+     *
+     * @param activity the current activity
+     * @param result the collected data including screenshots, attachments, and debug info
+     */
+    public void performCustomActionOnShake(@NonNull Activity activity, @NonNull Result result) {
+        // Default implementation: fall back to the deprecated method for backward compatibility
+        performCustomActionOnShake(activity);
+    }
 
     /**
      * @return if the dialog should be shown on shake or the shake-to-feedback bottom sheet.

--- a/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
+++ b/shaky/src/main/java/com/linkedin/android/shaky/Shaky.java
@@ -238,11 +238,8 @@ public class Shaky implements ShakeDetector.Listener {
                 return;
             }
 
-            delegate.performCustomActionOnShake(activity);
-
-            if (shakyFlowCallback != null) {
-                shakyFlowCallback.onUserPromptShown();
-            }
+            actionThatStartedTheActivity = ActionConstants.ACTION_START_FEEDBACK_FLOW;
+            doStartFeedbackFlow();
         } else {
             launchShakeBottomSheet(ShakyFlowCallback.SHAKY_STARTED_BY_SHAKE);
         }
@@ -510,6 +507,18 @@ public class Shaky implements ShakeDetector.Listener {
                 collectDataTask = null;
                 dismissCollectFeedbackDialogIfNecessary();
                 Result safeResult = result != null ? result : new Result();
+
+                // Handle custom shake flow
+                if (delegate.isCustomHandlingOfShakeEnabled()) {
+                    if (activity != null) {
+                        delegate.performCustomActionOnShake(activity, safeResult);
+                    }
+
+                    if (shakyFlowCallback != null) {
+                        shakyFlowCallback.onShakyStarted(ShakyFlowCallback.SHAKY_STARTED_BY_SHAKE);
+                    }
+                    return;
+                }
 
                 if (shouldStartFeedbackActivity && !isBottomSheetFlowActive) {
                     startFeedbackActivity(safeResult);


### PR DESCRIPTION
## Summary

Enable data collection in custom action

- Added a new overloaded method to enable data collection when custom
  action is performed.
- Added support to provide the collected result which contains data
  such as screenshots, debug info, and attachments.
- Marked the old method as deprecated.
- Updated shaky to initiate data collection in custom flow when shake
  is detected.

## Testing done

Tested locally in integrating app and verified that the changes work as expected.